### PR TITLE
refactor: clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Certora"]
 description = "Certora Verification Language for Rust"
 documentation = "https://certora.com"

--- a/cvlr-early-panic/src/lib.rs
+++ b/cvlr-early-panic/src/lib.rs
@@ -4,8 +4,6 @@ use syn::visit_mut::{self, VisitMut};
 use syn::{parse_macro_input, parse_quote, Expr, ItemFn};
 
 /// Replaces question mark operator by unwrap
-///
-
 struct EarlyPanic;
 
 impl VisitMut for EarlyPanic {

--- a/cvlr-fixed/src/native_fixed.rs
+++ b/cvlr-fixed/src/native_fixed.rs
@@ -161,6 +161,7 @@ macro_rules! native_fixed {
             }
         }
 
+        #[allow(clippy::non_canonical_partial_ord_impl)]
         impl<const F: u32> core::cmp::PartialOrd for $NativeFixed<F> {
             fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
                 self.val.partial_cmp(&other.val)

--- a/cvlr-log/src/core.rs
+++ b/cvlr-log/src/core.rs
@@ -48,6 +48,7 @@ mod rt_impls {
 }
 pub use rt_decls::*;
 
+#[derive(Default)]
 pub struct CvlrLogger;
 
 impl CvlrLogger {

--- a/cvlr-log/src/log.rs
+++ b/cvlr-log/src/log.rs
@@ -87,7 +87,7 @@ impl<T: CvlrLog> CvlrLog for &T {
 impl CvlrLog for &str {
     #[inline(always)]
     fn log(&self, _tag: &str, logger: &mut CvlrLogger) {
-        logger.log(*self);
+        logger.log(self);
     }
 }
 

--- a/cvlr-mathint/src/nativeint_u64.rs
+++ b/cvlr-mathint/src/nativeint_u64.rs
@@ -220,6 +220,10 @@ impl PartialEq for NativeIntU64 {
 }
 
 impl PartialOrd for NativeIntU64 {
+    // We silence these two warnings from clippy: this code should be left as-is
+    // for the Certora Prover TAC slicer.
+    #[allow(clippy::non_canonical_partial_ord_impl)]
+    #[allow(clippy::comparison_chain)]
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         let ord = if self.0 == other.0 {
             core::cmp::Ordering::Equal
@@ -246,9 +250,9 @@ impl PartialOrd for NativeIntU64 {
 
 impl Ord for NativeIntU64 {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        if self.lt(&other) {
+        if self.lt(other) {
             core::cmp::Ordering::Less
-        } else if self.gt(&other) {
+        } else if self.gt(other) {
             core::cmp::Ordering::Greater
         } else {
             core::cmp::Ordering::Equal

--- a/cvlr-nondet/src/havoc.rs
+++ b/cvlr-nondet/src/havoc.rs
@@ -15,7 +15,8 @@ mod rt_imps {
     }
 }
 
-pub fn memhavoc(data: *mut u8, size: usize) {
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn memhavoc(data: *mut u8, size: usize) {
     unsafe {
         rt_decls::memhavoc_c(data, size);
     }

--- a/cvlr-nondet/src/havoc.rs
+++ b/cvlr-nondet/src/havoc.rs
@@ -31,9 +31,9 @@ pub fn alloc_havoced<T: Sized>() -> *mut T {
 }
 
 pub fn alloc_ref_havoced<T: Sized>() -> &'static T {
-    unsafe { return &*alloc_havoced::<T>() }
+    unsafe { &*alloc_havoced::<T>() }
 }
 
 pub fn alloc_mut_ref_havoced<T: Sized>() -> &'static mut T {
-    unsafe { return &mut *alloc_havoced::<T>() }
+    unsafe { &mut *alloc_havoced::<T>() }
 }


### PR DESCRIPTION
I implemented the changes suggested by `clippy`.
Observe that I had to mark `memhavoc` as unsafe, and I also changed the implementation of `partial_cmp` for `NativeIntU64`.
If this is not OK, we can disable the warnings I had there.