### PR TITLE
Remove rule location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+  - Injection of `CVT_rule_location` macro in `#[rule]` macro
 
 ## [0.4.1] - 2025-05-14
 

--- a/cvlr-log/src/core.rs
+++ b/cvlr-log/src/core.rs
@@ -20,8 +20,6 @@ pub mod rt_decls {
         pub fn CVT_calltrace_print_location(file: &str, line: u64);
         pub fn CVT_calltrace_attach_location(file: &str, line: u64);
 
-        pub fn CVT_rule_location(file: &str, line: u64);
-
         pub fn CVT_calltrace_scope_start(name: &str);
         pub fn CVT_calltrace_scope_end(name: &str);
     }
@@ -55,8 +53,6 @@ mod rt_impls {
     pub extern "C" fn CVT_calltrace_print_location(_tag: &str, v: u64) {}
     #[no_mangle]
     pub extern "C" fn CVT_calltrace_attach_location(_tag: &str, v: u64) {}
-    #[no_mangle]
-    pub extern "C" fn CVT_rule_location(_file: &str, _line: u64) {}
     #[no_mangle]
     pub extern "C" fn CVT_calltrace_scope_start(name: &str) {}
     #[no_mangle]
@@ -150,13 +146,6 @@ impl CvlrLogger {
     }
 
     #[inline(always)]
-    pub fn log_rule_location(&mut self, file: &str, line: u64) {
-        unsafe {
-            crate::CVT_rule_location(file, line);
-        }
-    }
-
-    #[inline(always)]
     pub fn log_scope_start(&mut self, scope: &str) {
         unsafe {
             CVT_calltrace_scope_start(scope);
@@ -181,12 +170,6 @@ pub fn log(v: &str) {
 pub fn log_u64_as_fp(t: &str, v: u64, b: u64) {
     let mut logger = CvlrLogger::new();
     logger.log_u64_as_fp(t, v, b);
-}
-
-#[inline(always)]
-pub fn log_rule_location(file: &str, line: u64) {
-    let mut logger = CvlrLogger::new();
-    logger.log_rule_location(file, line);
 }
 
 #[inline(always)]
@@ -218,10 +201,3 @@ expose_log_fn! {log_u128, u128}
 expose_log_fn! {log_i128, i128}
 expose_log_fn! {log_loc, u32}
 expose_log_fn! {add_loc, u32}
-
-#[macro_export]
-macro_rules! cvlr_rule_location {
-    () => {{
-        $crate::log_rule_location(std::file!(), std::line!() as u64)
-    }};
-}

--- a/cvlr-macros/src/lib.rs
+++ b/cvlr-macros/src/lib.rs
@@ -20,12 +20,6 @@ pub fn rule(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut fn_ast = parse_macro_input!(item as ItemFn);
     // add #[no_mangle] attribute
     fn_ast.attrs.push(parse_quote! { #[no_mangle] });
-    // The first statement in rules is a call to the macro `cvlr_rule_location!`
-    // to automatically insert the location of the rule.
-    fn_ast
-        .block
-        .stmts
-        .insert(0, parse_quote! { cvlr::log::cvlr_rule_location!(); });
     fn_ast
         .block
         .stmts


### PR DESCRIPTION
The Prover will fetch (in the next release) the rule location from debug information, so there is no longer a need to read the rule location from `CVT_rule_location`.
This can be merged in `master`, but we should make the next release once the feature is publicly available.