### PR TITLE
fix: NativeFixed::to_bits

### DIFF
--- a/cvlr-fixed/src/native_fixed.rs
+++ b/cvlr-fixed/src/native_fixed.rs
@@ -31,7 +31,7 @@ macro_rules! native_fixed {
             }
 
             pub fn to_bits(&self) -> $uint {
-                cvlr_assume!(self.val.is_u64());
+                cvlr_assume!(self.val.$is_uint());
                 self.val.into()
             }
 


### PR DESCRIPTION
was using u64 independently of the base width.
switched to `$is_uint`