### PR TITLE
Extra features in assert and log macros

### DIFF
--- a/cvlr-asserts/Cargo.toml
+++ b/cvlr-asserts/Cargo.toml
@@ -16,6 +16,7 @@ repository.workspace = true
 [features]
 vacuity = []
 rt = []
+no-loc = []
 
 [dependencies]
 

--- a/cvlr-asserts/Cargo.toml
+++ b/cvlr-asserts/Cargo.toml
@@ -24,3 +24,4 @@ no-loc = []
 # path-dependency to break cyclic dev dependency on crates
 cvlr = { path = "../cvlr", features = ["rt"] }
 cvlr-asserts = { path = ".", features = ["rt"] }
+macrotest = { workspace = true }

--- a/cvlr-asserts/src/asserts.rs
+++ b/cvlr-asserts/src/asserts.rs
@@ -6,7 +6,7 @@ macro_rules! impl_bin_assert {
         ($lhs: expr, $rhs: expr $dollar(, $desc: literal)? ) => {{
             let lhs = $lhs;
             let rhs = $rhs;
-            cvlr::clog!(stringify!(assert $lhs $pred $rhs));
+            cvlr::clog!(stringify!(assert $lhs $pred $rhs) => "_");
             cvlr::clog!(lhs => stringify!($lhs));
             cvlr::clog!(rhs => stringify!($rhs));
             $crate::cvlr_assert!(lhs $pred rhs);
@@ -31,7 +31,7 @@ macro_rules! impl_bin_assume {
         ($lhs: expr, $rhs: expr $dollar(, $desc: literal)? ) => {{
             let lhs = $lhs;
             let rhs = $rhs;
-            cvlr::clog!(stringify!(assume $lhs $pred $rhs));
+            cvlr::clog!(stringify!(assume $lhs $pred $rhs) => "_");
             cvlr::clog!(lhs => stringify!($lhs));
             cvlr::clog!(rhs => stringify!($rhs));
             $crate::cvlr_assume!(lhs $pred rhs);
@@ -64,7 +64,7 @@ macro_rules! impl_bin_assert_if {
         macro_rules! $name {
         ($guard: expr,$lhs: expr, $rhs: expr $dollar(, $desc: literal)? ) => {{
             let guard = $guard;
-            cvlr::clog!(stringify!(assert $guard ==> $lhs $pred $rhs));
+            cvlr::clog!(stringify!(assert $guard ==> $lhs $pred $rhs) => "_");
             cvlr::clog!(guard => stringify!($guard));
             if guard {
                 let lhs = $lhs;

--- a/cvlr-asserts/src/asserts.rs
+++ b/cvlr-asserts/src/asserts.rs
@@ -47,3 +47,41 @@ impl_bin_assume!(cvlr_assume_le, <=, $);
 impl_bin_assume!(cvlr_assume_lt, <, $);
 impl_bin_assume!(cvlr_assume_ge, >=, $);
 impl_bin_assume!(cvlr_assume_gt, >, $);
+
+#[macro_export]
+macro_rules! cvlr_assert_if {
+    ($guard: expr, $cond: expr) => {
+        if $guard {
+            $crate::cvlr_assert!($cond);
+        }
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! impl_bin_assert_if {
+    ($name: ident, $pred: tt, $dollar: tt) => {
+        #[macro_export]
+        macro_rules! $name {
+        ($guard: expr,$lhs: expr, $rhs: expr $dollar(, $desc: literal)? ) => {{
+            let guard = $guard;
+            cvlr::clog!(stringify!(assert $guard ==> $lhs $pred $rhs));
+            cvlr::clog!(guard => stringify!($guard));
+            if guard {
+                let lhs = $lhs;
+                let rhs = $rhs;
+                cvlr::clog!(lhs => stringify!($lhs));
+                cvlr::clog!(rhs => stringify!($rhs));
+                $crate::cvlr_assert!(lhs $pred rhs);
+            }
+        }};
+    }
+        pub use $name;
+    };
+}
+
+impl_bin_assert_if!(cvlr_assert_eq_if, ==, $);
+impl_bin_assert_if!(cvlr_assert_ne_if, !=, $);
+impl_bin_assert_if!(cvlr_assert_le_if, <=, $);
+impl_bin_assert_if!(cvlr_assert_lt_if, <, $);
+impl_bin_assert_if!(cvlr_assert_ge_if, >=, $);
+impl_bin_assert_if!(cvlr_assert_gt_if, >, $);

--- a/cvlr-asserts/src/core.rs
+++ b/cvlr-asserts/src/core.rs
@@ -67,7 +67,7 @@ macro_rules! cvlr_assert {
     ($cond: expr $(, $desc: literal)?) => {{
         let c_ = $cond;
         $crate::add_loc!();
-        $crate::cvlr_assert_checked(c_)
+        $crate::cvlr_assert_checked(c_);
     }};
 }
 
@@ -83,7 +83,7 @@ macro_rules! cvlr_satisfy {
     ($cond: expr $(, $desc: literal)?) => {{
         let c_ = $cond;
         $crate::add_loc!();
-        $crate::cvlr_satisfy_checked(c_)
+        $crate::cvlr_satisfy_checked(c_);
     }};
 }
 

--- a/cvlr-asserts/src/log.rs
+++ b/cvlr-asserts/src/log.rs
@@ -13,9 +13,44 @@ pub fn add_loc(file: &str, line: u32) {
     }
 }
 
+#[cfg(not(feature = "no-loc"))]
+#[macro_export]
+macro_rules! cvlr_asserts_core_file {
+    () => {
+        ::core::file!()
+    };
+}
+
+#[cfg(not(feature = "no-loc"))]
+#[macro_export]
+macro_rules! cvlr_asserts_core_line {
+    () => {
+        ::core::line!()
+    };
+}
+
+#[cfg(feature = "no-loc")]
+#[macro_export]
+macro_rules! cvlr_asserts_core_file {
+    () => {
+        "<FILE>"
+    };
+}
+
+#[cfg(feature = "no-loc")]
+#[macro_export]
+macro_rules! cvlr_asserts_core_line {
+    () => {
+        0u32
+    };
+}
+
 #[macro_export]
 macro_rules! add_loc {
     () => {
-        $crate::log::add_loc(core::file!(), core::line!());
+        $crate::log::add_loc(
+            $crate::cvlr_asserts_core_file!(),
+            $crate::cvlr_asserts_core_line!(),
+        );
     };
 }

--- a/cvlr-asserts/tests/expand/test_add_loc.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_add_loc.expanded.rs
@@ -1,0 +1,4 @@
+use cvlr_asserts::add_loc;
+fn main() {
+    ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+}

--- a/cvlr-asserts/tests/expand/test_add_loc.rs
+++ b/cvlr-asserts/tests/expand/test_add_loc.rs
@@ -1,0 +1,5 @@
+use cvlr_asserts::add_loc;
+
+fn main() {
+    add_loc!();
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert.expanded.rs
@@ -1,0 +1,23 @@
+use cvlr_asserts::cvlr_assert;
+fn main() {
+    {
+        let c_ = true;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = 1 == 1;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = false;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = x > 0;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert.rs
@@ -1,0 +1,8 @@
+use cvlr_asserts::cvlr_assert;
+
+fn main() {
+    cvlr_assert!(true);
+    cvlr_assert!(1 == 1);
+    cvlr_assert!(false, "this should fail");
+    cvlr_assert!(x > 0, "x must be positive");
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_comparison.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_comparison.expanded.rs
@@ -3,7 +3,7 @@ fn main() {
     {
         let lhs = 1;
         let rhs = 2;
-        ::cvlr_log::cvlr_log("stringify! (assert 1 <= 2)", &("assert 1 <= 2"));
+        ::cvlr_log::cvlr_log("_", &("assert 1 <= 2"));
         ::cvlr_log::cvlr_log("1", &(lhs));
         ::cvlr_log::cvlr_log("2", &(rhs));
         {
@@ -15,7 +15,7 @@ fn main() {
     {
         let lhs = 1;
         let rhs = 2;
-        ::cvlr_log::cvlr_log("stringify! (assert 1 < 2)", &("assert 1 < 2"));
+        ::cvlr_log::cvlr_log("_", &("assert 1 < 2"));
         ::cvlr_log::cvlr_log("1", &(lhs));
         ::cvlr_log::cvlr_log("2", &(rhs));
         {
@@ -27,7 +27,7 @@ fn main() {
     {
         let lhs = 2;
         let rhs = 1;
-        ::cvlr_log::cvlr_log("stringify! (assert 2 >= 1)", &("assert 2 >= 1"));
+        ::cvlr_log::cvlr_log("_", &("assert 2 >= 1"));
         ::cvlr_log::cvlr_log("2", &(lhs));
         ::cvlr_log::cvlr_log("1", &(rhs));
         {
@@ -39,7 +39,7 @@ fn main() {
     {
         let lhs = 2;
         let rhs = 1;
-        ::cvlr_log::cvlr_log("stringify! (assert 2 > 1)", &("assert 2 > 1"));
+        ::cvlr_log::cvlr_log("_", &("assert 2 > 1"));
         ::cvlr_log::cvlr_log("2", &(lhs));
         ::cvlr_log::cvlr_log("1", &(rhs));
         {
@@ -51,7 +51,7 @@ fn main() {
     {
         let lhs = x;
         let rhs = y;
-        ::cvlr_log::cvlr_log("stringify! (assert x <= y)", &("assert x <= y"));
+        ::cvlr_log::cvlr_log("_", &("assert x <= y"));
         ::cvlr_log::cvlr_log("x", &(lhs));
         ::cvlr_log::cvlr_log("y", &(rhs));
         {

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_comparison.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_comparison.expanded.rs
@@ -1,0 +1,63 @@
+use cvlr_asserts::{cvlr_assert_le, cvlr_assert_lt, cvlr_assert_ge, cvlr_assert_gt};
+fn main() {
+    {
+        let lhs = 1;
+        let rhs = 2;
+        ::cvlr_log::cvlr_log("stringify! (assert 1 <= 2)", &("assert 1 <= 2"));
+        ::cvlr_log::cvlr_log("1", &(lhs));
+        ::cvlr_log::cvlr_log("2", &(rhs));
+        {
+            let c_ = lhs <= rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = 1;
+        let rhs = 2;
+        ::cvlr_log::cvlr_log("stringify! (assert 1 < 2)", &("assert 1 < 2"));
+        ::cvlr_log::cvlr_log("1", &(lhs));
+        ::cvlr_log::cvlr_log("2", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = 2;
+        let rhs = 1;
+        ::cvlr_log::cvlr_log("stringify! (assert 2 >= 1)", &("assert 2 >= 1"));
+        ::cvlr_log::cvlr_log("2", &(lhs));
+        ::cvlr_log::cvlr_log("1", &(rhs));
+        {
+            let c_ = lhs >= rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = 2;
+        let rhs = 1;
+        ::cvlr_log::cvlr_log("stringify! (assert 2 > 1)", &("assert 2 > 1"));
+        ::cvlr_log::cvlr_log("2", &(lhs));
+        ::cvlr_log::cvlr_log("1", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("stringify! (assert x <= y)", &("assert x <= y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        {
+            let c_ = lhs <= rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_comparison.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_comparison.rs
@@ -1,0 +1,9 @@
+use cvlr_asserts::{cvlr_assert_le, cvlr_assert_lt, cvlr_assert_ge, cvlr_assert_gt};
+
+fn main() {
+    cvlr_assert_le!(1, 2);
+    cvlr_assert_lt!(1, 2);
+    cvlr_assert_ge!(2, 1);
+    cvlr_assert_gt!(2, 1);
+    cvlr_assert_le!(x, y, "x must be <= y");
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_eq.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_eq.expanded.rs
@@ -3,7 +3,7 @@ fn main() {
     {
         let lhs = 1;
         let rhs = 1;
-        ::cvlr_log::cvlr_log("stringify! (assert 1 == 1)", &("assert 1 == 1"));
+        ::cvlr_log::cvlr_log("_", &("assert 1 == 1"));
         ::cvlr_log::cvlr_log("1", &(lhs));
         ::cvlr_log::cvlr_log("1", &(rhs));
         {
@@ -15,7 +15,7 @@ fn main() {
     {
         let lhs = x;
         let rhs = y;
-        ::cvlr_log::cvlr_log("stringify! (assert x == y)", &("assert x == y"));
+        ::cvlr_log::cvlr_log("_", &("assert x == y"));
         ::cvlr_log::cvlr_log("x", &(lhs));
         ::cvlr_log::cvlr_log("y", &(rhs));
         {
@@ -27,7 +27,7 @@ fn main() {
     {
         let lhs = a;
         let rhs = b;
-        ::cvlr_log::cvlr_log("stringify! (assert a == b)", &("assert a == b"));
+        ::cvlr_log::cvlr_log("_", &("assert a == b"));
         ::cvlr_log::cvlr_log("a", &(lhs));
         ::cvlr_log::cvlr_log("b", &(rhs));
         {

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_eq.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_eq.expanded.rs
@@ -1,0 +1,39 @@
+use cvlr_asserts::cvlr_assert_eq;
+fn main() {
+    {
+        let lhs = 1;
+        let rhs = 1;
+        ::cvlr_log::cvlr_log("stringify! (assert 1 == 1)", &("assert 1 == 1"));
+        ::cvlr_log::cvlr_log("1", &(lhs));
+        ::cvlr_log::cvlr_log("1", &(rhs));
+        {
+            let c_ = lhs == rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("stringify! (assert x == y)", &("assert x == y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        {
+            let c_ = lhs == rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("stringify! (assert a == b)", &("assert a == b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        {
+            let c_ = lhs == rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_eq.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_eq.rs
@@ -1,0 +1,7 @@
+use cvlr_asserts::cvlr_assert_eq;
+
+fn main() {
+    cvlr_assert_eq!(1, 1);
+    cvlr_assert_eq!(x, y);
+    cvlr_assert_eq!(a, b, "a and b must be equal");
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_eq_if.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_eq_if.expanded.rs
@@ -1,0 +1,41 @@
+use cvlr_asserts::cvlr_assert_eq_if;
+fn main() {
+    {
+        let guard = x > 0;
+        ::cvlr_log::cvlr_log(
+            "stringify! (assert x > 0 == > a == b)",
+            &("assert x > 0 == > a == b"),
+        );
+        ::cvlr_log::cvlr_log("x > 0", &(guard));
+        if guard {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            {
+                let c_ = lhs == rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = flag;
+        ::cvlr_log::cvlr_log(
+            "stringify! (assert flag == > x == y)",
+            &("assert flag == > x == y"),
+        );
+        ::cvlr_log::cvlr_log("flag", &(guard));
+        if guard {
+            let lhs = x;
+            let rhs = y;
+            ::cvlr_log::cvlr_log("x", &(lhs));
+            ::cvlr_log::cvlr_log("y", &(rhs));
+            {
+                let c_ = lhs == rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_eq_if.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_eq_if.expanded.rs
@@ -1,11 +1,14 @@
 use cvlr_asserts::cvlr_assert_eq_if;
 fn main() {
+    let x = 1;
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    let x = 2;
+    let y = 2;
     {
         let guard = x > 0;
-        ::cvlr_log::cvlr_log(
-            "stringify! (assert x > 0 == > a == b)",
-            &("assert x > 0 == > a == b"),
-        );
+        ::cvlr_log::cvlr_log("_", &("assert x > 0 == > a == b"));
         ::cvlr_log::cvlr_log("x > 0", &(guard));
         if guard {
             let lhs = a;
@@ -21,10 +24,7 @@ fn main() {
     };
     {
         let guard = flag;
-        ::cvlr_log::cvlr_log(
-            "stringify! (assert flag == > x == y)",
-            &("assert flag == > x == y"),
-        );
+        ::cvlr_log::cvlr_log("_", &("assert flag == > x == y"));
         ::cvlr_log::cvlr_log("flag", &(guard));
         if guard {
             let lhs = x;

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_eq_if.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_eq_if.rs
@@ -1,0 +1,6 @@
+use cvlr_asserts::cvlr_assert_eq_if;
+
+fn main() {
+    cvlr_assert_eq_if!(x > 0, a, b);
+    cvlr_assert_eq_if!(flag, x, y, "if flag then x == y");
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_eq_if.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_eq_if.rs
@@ -1,6 +1,12 @@
 use cvlr_asserts::cvlr_assert_eq_if;
 
 fn main() {
+    let x = 1;
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    let x = 2;
+    let y = 2;
     cvlr_assert_eq_if!(x > 0, a, b);
     cvlr_assert_eq_if!(flag, x, y, "if flag then x == y");
 }

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_if.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_if.expanded.rs
@@ -1,0 +1,17 @@
+use cvlr_asserts::cvlr_assert_if;
+fn main() {
+    if x > 0 {
+        {
+            let c_ = y > 0;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    }
+    if flag {
+        {
+            let c_ = value == expected;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    }
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_if.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_if.rs
@@ -1,0 +1,6 @@
+use cvlr_asserts::cvlr_assert_if;
+
+fn main() {
+    cvlr_assert_if!(x > 0, y > 0);
+    cvlr_assert_if!(flag, value == expected);
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_ne.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_ne.expanded.rs
@@ -1,0 +1,39 @@
+use cvlr_asserts::cvlr_assert_ne;
+fn main() {
+    {
+        let lhs = 1;
+        let rhs = 2;
+        ::cvlr_log::cvlr_log("stringify! (assert 1 != 2)", &("assert 1 != 2"));
+        ::cvlr_log::cvlr_log("1", &(lhs));
+        ::cvlr_log::cvlr_log("2", &(rhs));
+        {
+            let c_ = lhs != rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("stringify! (assert x != y)", &("assert x != y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        {
+            let c_ = lhs != rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("stringify! (assert a != b)", &("assert a != b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        {
+            let c_ = lhs != rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_ne.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_ne.expanded.rs
@@ -3,7 +3,7 @@ fn main() {
     {
         let lhs = 1;
         let rhs = 2;
-        ::cvlr_log::cvlr_log("stringify! (assert 1 != 2)", &("assert 1 != 2"));
+        ::cvlr_log::cvlr_log("_", &("assert 1 != 2"));
         ::cvlr_log::cvlr_log("1", &(lhs));
         ::cvlr_log::cvlr_log("2", &(rhs));
         {
@@ -15,7 +15,7 @@ fn main() {
     {
         let lhs = x;
         let rhs = y;
-        ::cvlr_log::cvlr_log("stringify! (assert x != y)", &("assert x != y"));
+        ::cvlr_log::cvlr_log("_", &("assert x != y"));
         ::cvlr_log::cvlr_log("x", &(lhs));
         ::cvlr_log::cvlr_log("y", &(rhs));
         {
@@ -27,7 +27,7 @@ fn main() {
     {
         let lhs = a;
         let rhs = b;
-        ::cvlr_log::cvlr_log("stringify! (assert a != b)", &("assert a != b"));
+        ::cvlr_log::cvlr_log("_", &("assert a != b"));
         ::cvlr_log::cvlr_log("a", &(lhs));
         ::cvlr_log::cvlr_log("b", &(rhs));
         {

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_ne.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_ne.rs
@@ -1,0 +1,7 @@
+use cvlr_asserts::cvlr_assert_ne;
+
+fn main() {
+    cvlr_assert_ne!(1, 2);
+    cvlr_assert_ne!(x, y);
+    cvlr_assert_ne!(a, b, "a and b must not be equal");
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assume.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assume.expanded.rs
@@ -1,0 +1,6 @@
+use cvlr_asserts::cvlr_assume;
+fn main() {
+    ::cvlr_asserts::cvlr_assume_checked(true);
+    ::cvlr_asserts::cvlr_assume_checked(x > 0);
+    ::cvlr_asserts::cvlr_assume_checked(y < 100);
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assume.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assume.rs
@@ -1,0 +1,7 @@
+use cvlr_asserts::cvlr_assume;
+
+fn main() {
+    cvlr_assume!(true);
+    cvlr_assume!(x > 0);
+    cvlr_assume!(y < 100, "y must be less than 100");
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assume_eq.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assume_eq.expanded.rs
@@ -3,7 +3,7 @@ fn main() {
     {
         let lhs = 1;
         let rhs = 1;
-        ::cvlr_log::cvlr_log("stringify! (assume 1 == 1)", &("assume 1 == 1"));
+        ::cvlr_log::cvlr_log("_", &("assume 1 == 1"));
         ::cvlr_log::cvlr_log("1", &(lhs));
         ::cvlr_log::cvlr_log("1", &(rhs));
         ::cvlr_asserts::cvlr_assume_checked(lhs == rhs);
@@ -11,7 +11,7 @@ fn main() {
     {
         let lhs = x;
         let rhs = y;
-        ::cvlr_log::cvlr_log("stringify! (assume x == y)", &("assume x == y"));
+        ::cvlr_log::cvlr_log("_", &("assume x == y"));
         ::cvlr_log::cvlr_log("x", &(lhs));
         ::cvlr_log::cvlr_log("y", &(rhs));
         ::cvlr_asserts::cvlr_assume_checked(lhs == rhs);
@@ -19,7 +19,7 @@ fn main() {
     {
         let lhs = a;
         let rhs = b;
-        ::cvlr_log::cvlr_log("stringify! (assume a == b)", &("assume a == b"));
+        ::cvlr_log::cvlr_log("_", &("assume a == b"));
         ::cvlr_log::cvlr_log("a", &(lhs));
         ::cvlr_log::cvlr_log("b", &(rhs));
         ::cvlr_asserts::cvlr_assume_checked(lhs == rhs);

--- a/cvlr-asserts/tests/expand/test_cvlr_assume_eq.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assume_eq.expanded.rs
@@ -1,0 +1,27 @@
+use cvlr_asserts::cvlr_assume_eq;
+fn main() {
+    {
+        let lhs = 1;
+        let rhs = 1;
+        ::cvlr_log::cvlr_log("stringify! (assume 1 == 1)", &("assume 1 == 1"));
+        ::cvlr_log::cvlr_log("1", &(lhs));
+        ::cvlr_log::cvlr_log("1", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs == rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("stringify! (assume x == y)", &("assume x == y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs == rhs);
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("stringify! (assume a == b)", &("assume a == b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs == rhs);
+    };
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_assume_eq.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assume_eq.rs
@@ -1,0 +1,7 @@
+use cvlr_asserts::cvlr_assume_eq;
+
+fn main() {
+    cvlr_assume_eq!(1, 1);
+    cvlr_assume_eq!(x, y);
+    cvlr_assume_eq!(a, b, "assume a equals b");
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_satisfy.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_satisfy.expanded.rs
@@ -1,0 +1,18 @@
+use cvlr_asserts::cvlr_satisfy;
+fn main() {
+    {
+        let c_ = true;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_satisfy_checked(c_);
+    };
+    {
+        let c_ = x == y;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_satisfy_checked(c_);
+    };
+    {
+        let c_ = z > 0;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_satisfy_checked(c_);
+    };
+}

--- a/cvlr-asserts/tests/expand/test_cvlr_satisfy.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_satisfy.rs
@@ -1,0 +1,7 @@
+use cvlr_asserts::cvlr_satisfy;
+
+fn main() {
+    cvlr_satisfy!(true);
+    cvlr_satisfy!(x == y);
+    cvlr_satisfy!(z > 0, "z must be positive");
+}

--- a/cvlr-asserts/tests/test_asserts.rs
+++ b/cvlr-asserts/tests/test_asserts.rs
@@ -6,6 +6,11 @@ extern crate cvlr;
 #[cfg(feature = "rt")]
 use cvlr_asserts::*;
 
+#[test]
+fn test_cvlr_asserts_macro_expansion() {
+    macrotest::expand_args("tests/expand/*.rs", &["--features", "no-loc"]);
+}
+
 #[cfg(feature = "rt")]
 #[test]
 fn test_assert_eq_pass() {

--- a/cvlr-log/src/log.rs
+++ b/cvlr-log/src/log.rs
@@ -64,6 +64,12 @@ macro_rules! cvlr_log {
         $crate::cvlr_log! { $( $vs => $ts ),+ }
     };
 
+    // first labeled, rest can be mixed (labeled or unlabeled)
+    ($v:expr => $t:expr, $( $rest:tt )+) => {
+        $crate::cvlr_log! { $v => $t }
+        $crate::cvlr_log! { $( $rest )+ }
+    };
+
     ($v:expr => $t:expr) => {
         // TODO: enable when this becomes stable
         // $crate::add_loc(core::file!(), core::line!());
@@ -74,9 +80,10 @@ macro_rules! cvlr_log {
         $crate::cvlr_log! { $v => stringify!($v) }
     };
 
-    ($v:expr, $( $vs:expr ),+ $(,)?) => {
+    // first unlabeled, rest can be mixed (labeled or unlabeled)
+    ($v:expr, $( $rest:tt )+) => {
         $crate::cvlr_log! { $v }
-        $crate::cvlr_log! { $( $vs ),+ }
+        $crate::cvlr_log! { $( $rest )+ }
     };
 }
 

--- a/cvlr-log/tests/expand/test_cvlr_log_mixed.expanded.rs
+++ b/cvlr-log/tests/expand/test_cvlr_log_mixed.expanded.rs
@@ -1,0 +1,22 @@
+use cvlr_log::cvlr_log;
+fn main() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    ::cvlr_log::cvlr_log("a", &(a));
+    ::cvlr_log::cvlr_log("b", &(b));
+    ::cvlr_log::cvlr_log("a", &(a));
+    ::cvlr_log::cvlr_log("b", &(b));
+    ::cvlr_log::cvlr_log("c", &(c));
+    ::cvlr_log::cvlr_log("a", &(a));
+    ::cvlr_log::cvlr_log("b", &(b));
+    ::cvlr_log::cvlr_log("a", &(a));
+    ::cvlr_log::cvlr_log("b", &(b));
+    ::cvlr_log::cvlr_log("c", &(c));
+    ::cvlr_log::cvlr_log("a", &(a));
+    ::cvlr_log::cvlr_log("b", &(b));
+    ::cvlr_log::cvlr_log("c", &(c));
+    ::cvlr_log::cvlr_log("a", &(a));
+    ::cvlr_log::cvlr_log("b", &(b));
+    ::cvlr_log::cvlr_log("c", &(c));
+}

--- a/cvlr-log/tests/expand/test_cvlr_log_mixed.rs
+++ b/cvlr-log/tests/expand/test_cvlr_log_mixed.rs
@@ -1,0 +1,19 @@
+use cvlr_log::cvlr_log;
+
+fn main() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    
+    // Test: first labeled, rest unlabeled
+    cvlr_log!(a => "a", b);
+    cvlr_log!(a => "a", b, c);
+    
+    // Test: first unlabeled, rest labeled
+    cvlr_log!(a, b => "b");
+    cvlr_log!(a, b => "b", c => "c");
+    
+    // Test: mixed throughout
+    cvlr_log!(a => "a", b, c => "c");
+    cvlr_log!(a, b => "b", c);
+}


### PR DESCRIPTION
* `cvlr_assert_if` for guarded asserts
* macrotests for cvlr-asserts
* minor improvements and fixes throughout
* mixing labeled and unlabeled entries in `cvlr_log!` and `clog!` macros