### PR TITLE
New cvlr_assert macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ version = "0.4.1"
 dependencies = [
  "cvlr",
  "cvlr-asserts",
+ "macrotest",
 ]
 
 [[package]]
@@ -79,11 +80,12 @@ name = "cvlr-macros"
 version = "0.4.1"
 dependencies = [
  "cvlr",
- "cvlr-asserts",
  "darling",
+ "macrotest",
  "proc-macro2",
  "quote",
  "syn",
+ "trybuild",
 ]
 
 [[package]]

--- a/cvlr-asserts/src/asserts.rs
+++ b/cvlr-asserts/src/asserts.rs
@@ -64,7 +64,7 @@ macro_rules! impl_bin_assert_if {
         macro_rules! $name {
         ($guard: expr,$lhs: expr, $rhs: expr $dollar(, $desc: literal)? ) => {{
             let guard = $guard;
-            cvlr::clog!(stringify!(assert $guard ==> $lhs $pred $rhs) => "_");
+            cvlr::clog!(stringify!(assert if $guard { $lhs $pred $rhs }) => "_");
             cvlr::clog!(guard => stringify!($guard));
             if guard {
                 let lhs = $lhs;

--- a/cvlr-asserts/tests/expand/test_cvlr_assert_eq_if.expanded.rs
+++ b/cvlr-asserts/tests/expand/test_cvlr_assert_eq_if.expanded.rs
@@ -8,7 +8,7 @@ fn main() {
     let y = 2;
     {
         let guard = x > 0;
-        ::cvlr_log::cvlr_log("_", &("assert x > 0 == > a == b"));
+        ::cvlr_log::cvlr_log("_", &("assert if x > 0 { a == b }"));
         ::cvlr_log::cvlr_log("x > 0", &(guard));
         if guard {
             let lhs = a;
@@ -24,7 +24,7 @@ fn main() {
     };
     {
         let guard = flag;
-        ::cvlr_log::cvlr_log("_", &("assert flag == > x == y"));
+        ::cvlr_log::cvlr_log("_", &("assert if flag { x == y }"));
         ::cvlr_log::cvlr_log("flag", &(guard));
         if guard {
             let lhs = x;

--- a/cvlr-macros/Cargo.toml
+++ b/cvlr-macros/Cargo.toml
@@ -22,6 +22,7 @@ syn = { workspace = true }
 darling = "0.20" 
 
 [dev-dependencies]
-cvlr-asserts = { workspace = true }
 # path-dependency to break cyclic dev dependency on crates
-cvlr = { path = "../cvlr" }
+cvlr = { path = "../cvlr", features = ["rt", "no-loc"] }
+macrotest = { workspace = true }
+trybuild = { workspace = true }

--- a/cvlr-macros/src/assert_that.rs
+++ b/cvlr-macros/src/assert_that.rs
@@ -77,7 +77,7 @@ fn analyze_condition(condition: &Expr, guard: Option<&Expr>) -> syn::Result<Toke
             // Unguarded assertion: cvlr_assert_<op>!(lhs, rhs)
             let macro_ident = syn::Ident::new(macro_name, Span::call_site());
             Ok(quote! {
-                ::clvr::asserts::#macro_ident!(#left, #right);
+                ::cvlr::asserts::#macro_ident!(#left, #right);
             })
         }
     } else {
@@ -90,7 +90,7 @@ fn handle_boolean_condition(condition: &Expr, guard: Option<&Expr>) -> syn::Resu
     if let Some(guard_expr) = guard {
         // Guarded boolean: cvlr_assert_if!(guard, condition)
         Ok(quote! {
-            ::cvrl::asserts::cvlr_assert_if!(#guard_expr, #condition);
+            ::cvlr::asserts::cvlr_assert_if!(#guard_expr, #condition);
         })
     } else {
         // Unguarded boolean: cvlr_assert!(condition)

--- a/cvlr-macros/src/assert_that.rs
+++ b/cvlr-macros/src/assert_that.rs
@@ -169,3 +169,98 @@ pub fn assert_all_impl(input: TokenStream) -> TokenStream {
     }
     .into()
 }
+
+fn analyze_assume_condition(condition: &Expr, guard: Option<&Expr>) -> syn::Result<TokenStream2> {
+    // Check if condition is a binary comparison
+    if let Expr::Binary(bin) = condition {
+        let op = &bin.op;
+        let left = &bin.left;
+        let right = &bin.right;
+
+        // Determine the macro name based on the operator
+        let macro_name = match op {
+            syn::BinOp::Lt(_) => "cvlr_assume_lt",
+            syn::BinOp::Le(_) => "cvlr_assume_le",
+            syn::BinOp::Gt(_) => "cvlr_assume_gt",
+            syn::BinOp::Ge(_) => "cvlr_assume_ge",
+            syn::BinOp::Eq(_) => "cvlr_assume_eq",
+            syn::BinOp::Ne(_) => "cvlr_assume_ne",
+            _ => {
+                // Not a comparison operator, treat as boolean expression
+                return handle_assume_boolean_condition(condition, guard);
+            }
+        };
+
+        // Generate the macro call
+        if let Some(guard_expr) = guard {
+            // Guarded assumption: if guard { cvlr_assume_<op>!(lhs, rhs) }
+            // Note: There are no cvlr_assume_<op>_if macros, so we wrap in if
+            let macro_ident = syn::Ident::new(macro_name, Span::call_site());
+            Ok(quote! {
+                if #guard_expr {
+                    ::cvlr::asserts::#macro_ident!(#left, #right);
+                }
+            })
+        } else {
+            // Unguarded assumption: cvlr_assume_<op>!(lhs, rhs)
+            let macro_ident = syn::Ident::new(macro_name, Span::call_site());
+            Ok(quote! {
+                ::cvlr::asserts::#macro_ident!(#left, #right);
+            })
+        }
+    } else {
+        // Not a binary comparison, treat as boolean expression
+        handle_assume_boolean_condition(condition, guard)
+    }
+}
+
+fn handle_assume_boolean_condition(
+    condition: &Expr,
+    guard: Option<&Expr>,
+) -> syn::Result<TokenStream2> {
+    if let Some(guard_expr) = guard {
+        // Guarded boolean: if guard { cvlr_assume!(condition) }
+        Ok(quote! {
+            if #guard_expr {
+                ::cvlr::asserts::cvlr_assume!(#condition);
+            }
+        })
+    } else {
+        // Unguarded boolean: cvlr_assume!(condition)
+        Ok(quote! {
+            ::cvlr::asserts::cvlr_assume!(#condition);
+        })
+    }
+}
+
+pub fn assume_that_impl(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as AssertThatInput);
+
+    // Analyze the condition to detect comparison operators
+    let expanded = match analyze_assume_condition(&input.condition, input.guard.as_ref()) {
+        Ok(ts) => ts,
+        Err(e) => e.to_compile_error(),
+    };
+
+    expanded.into()
+}
+
+pub fn assume_all_impl(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as AssertAllInput);
+
+    // Generate the underlying assume macros directly for each expression
+    let mut assumptions = Vec::new();
+
+    for expr in &input.expressions {
+        match analyze_assume_condition(&expr.condition, expr.guard.as_ref()) {
+            Ok(assumption) => assumptions.push(assumption),
+            // stop on first error
+            Err(e) => return e.to_compile_error().into(),
+        }
+    }
+
+    quote! {
+        #(#assumptions)*
+    }
+    .into()
+}

--- a/cvlr-macros/src/assert_that.rs
+++ b/cvlr-macros/src/assert_that.rs
@@ -1,0 +1,101 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::quote;
+use syn::{parse::Parse, parse_macro_input, Expr, Token};
+
+// Custom parser for the assert_that DSL
+struct AssertThatInput {
+    guard: Option<Expr>,
+    condition: Expr,
+}
+
+impl Parse for AssertThatInput {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        // Try to parse as: guard => condition
+        let guard_expr: Expr = input.parse()?;
+
+        // Check if next token is =>
+        if input.peek(Token![=>]) {
+            let _arrow: Token![=>] = input.parse()?;
+            let condition: Expr = input.parse()?;
+            Ok(AssertThatInput {
+                guard: Some(guard_expr),
+                condition,
+            })
+        } else {
+            // No guard, the first expression is the condition
+            Ok(AssertThatInput {
+                guard: None,
+                condition: guard_expr,
+            })
+        }
+    }
+}
+
+pub fn assert_that_impl(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as AssertThatInput);
+
+    // Analyze the condition to detect comparison operators
+    let expanded = match analyze_condition(&input.condition, input.guard.as_ref()) {
+        Ok(ts) => ts,
+        Err(e) => e.to_compile_error(),
+    };
+
+    expanded.into()
+}
+
+fn analyze_condition(condition: &Expr, guard: Option<&Expr>) -> syn::Result<TokenStream2> {
+    // Check if condition is a binary comparison
+    if let Expr::Binary(bin) = condition {
+        let op = &bin.op;
+        let left = &bin.left;
+        let right = &bin.right;
+
+        // Determine the macro name based on the operator
+        let macro_name = match op {
+            syn::BinOp::Lt(_) => "cvlr_assert_lt",
+            syn::BinOp::Le(_) => "cvlr_assert_le",
+            syn::BinOp::Gt(_) => "cvlr_assert_gt",
+            syn::BinOp::Ge(_) => "cvlr_assert_ge",
+            syn::BinOp::Eq(_) => "cvlr_assert_eq",
+            syn::BinOp::Ne(_) => "cvlr_assert_ne",
+            _ => {
+                // Not a comparison operator, treat as boolean expression
+                return handle_boolean_condition(condition, guard);
+            }
+        };
+
+        // Generate the macro call
+        if let Some(guard_expr) = guard {
+            // Guarded assertion: cvlr_assert_<op>_if!(guard, lhs, rhs)
+            let macro_name_if = format!("{}_if", macro_name);
+            let macro_ident = syn::Ident::new(&macro_name_if, Span::call_site());
+            Ok(quote! {
+                ::cvlr::asserts::#macro_ident!(#guard_expr, #left, #right);
+            })
+        } else {
+            // Unguarded assertion: cvlr_assert_<op>!(lhs, rhs)
+            let macro_ident = syn::Ident::new(macro_name, Span::call_site());
+            Ok(quote! {
+                ::clvr::asserts::#macro_ident!(#left, #right);
+            })
+        }
+    } else {
+        // Not a binary comparison, treat as boolean expression
+        handle_boolean_condition(condition, guard)
+    }
+}
+
+fn handle_boolean_condition(condition: &Expr, guard: Option<&Expr>) -> syn::Result<TokenStream2> {
+    if let Some(guard_expr) = guard {
+        // Guarded boolean: cvlr_assert_if!(guard, condition)
+        Ok(quote! {
+            ::cvrl::asserts::cvlr_assert_if!(#guard_expr, #condition);
+        })
+    } else {
+        // Unguarded boolean: cvlr_assert!(condition)
+        Ok(quote! {
+            ::cvlr::asserts::cvlr_assert!(#condition);
+        })
+    }
+}

--- a/cvlr-macros/src/lib.rs
+++ b/cvlr-macros/src/lib.rs
@@ -38,6 +38,94 @@ pub fn mock_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
     mock::mock_fn_impl(attr, item)
 }
 
+/// Assert a condition using a DSL syntax
+///
+/// This macro provides a convenient DSL for writing assertions. It supports both
+/// guarded (conditional) and unguarded assertions, and automatically detects
+/// comparison operators to expand to the appropriate `cvlr_assert_*` macros.
+///
+/// # Syntax
+///
+/// The macro accepts either:
+/// - **Unguarded expression**: `cvlr_assert_that!(condition)`
+/// - **Guarded expression**: `cvlr_assert_that!(if guard { condition })`
+///
+/// The `condition` can be:
+/// - A comparison: `a < b`, `x >= y`, `p == q`, etc.
+/// - A boolean expression: `flag`, `x > 0 && y < 10`, etc.
+///
+/// # Examples
+///
+/// ## Unguarded comparisons
+///
+/// ```rust
+/// use cvlr_macros::cvlr_assert_that;
+///
+/// let x = 5;
+/// let y = 10;
+///
+/// cvlr_assert_that!(x < y);        // expands to cvlr_assert_lt!(x, y)
+/// cvlr_assert_that!(x <= y);       // expands to cvlr_assert_le!(x, y)
+/// cvlr_assert_that!(x > 0);        // expands to cvlr_assert_gt!(x, 0)
+/// cvlr_assert_that!(x >= 0);       // expands to cvlr_assert_ge!(x, 0)
+/// cvlr_assert_that!(x == 5);       // expands to cvlr_assert_eq!(x, 5)
+/// cvlr_assert_that!(x != 0);       // expands to cvlr_assert_ne!(x, 0)
+/// ```
+///
+/// ## Guarded comparisons
+///
+/// ```rust
+/// use cvlr_macros::cvlr_assert_that;
+///
+/// let flag = true;
+/// let a = 1;
+/// let b = 2;
+///
+/// // Assert b < a only if flag is true
+/// cvlr_assert_that!(if flag { a < b });  // expands to cvlr_assert_lt_if!(flag, a, b)
+/// cvlr_assert_that!(if x > 0 { y <= z }); // expands to cvlr_assert_le_if!(x > 0, y, z)
+/// ```
+///
+/// ## Boolean expressions
+///
+/// ```rust
+/// use cvlr_macros::cvlr_assert_that;
+///
+/// let flag = true;
+/// let x = 5;
+/// let y = 3;
+///
+/// // Unguarded boolean
+/// cvlr_assert_that!(flag);                    // expands to cvlr_assert!(flag)
+/// cvlr_assert_that!(x > 0 && y < 10);         // expands to cvlr_assert!(x > 0 && y < 10)
+///
+/// // Guarded boolean
+/// cvlr_assert_that!(if flag { x > 0 });       // expands to cvlr_assert_if!(flag, x > 0)
+/// cvlr_assert_that!(if x > 0 { y > 0 && z < 10 }); // expands to cvlr_assert_if!(x > 0, y > 0 && z < 10)
+/// ```
+///
+/// ## Complex expressions
+///
+/// ```rust
+/// use cvlr_macros::cvlr_assert_that;
+///
+/// let a = 1;
+/// let c = 3;
+/// let d = 4;
+/// let p = 5;
+///
+/// // Complex guard and condition
+/// cvlr_assert_that!(if a > c { d < p });      // expands to cvlr_assert_lt_if!(a > c, d, p)
+/// cvlr_assert_that!(if x + 1 > 0 { y * 2 < z }); // expands to cvlr_assert_lt_if!(x + 1 > 0, y * 2, z)
+/// ```
+///
+/// # Expansion
+///
+/// The macro automatically detects comparison operators and expands to the
+/// appropriate assertion macro:
+///
+/// - Comparisons (`<`, `<=`, `>`, `>=`, `==`, `!=`) expand to `cvlr_assert_<op>!` or `cvlr_assert_<op>_if!`
+/// - Boolean expressions expand to `cvlr_assert!` or `cvlr_assert_if!`
 #[proc_macro]
 pub fn cvlr_assert_that(input: TokenStream) -> TokenStream {
     assert_that::assert_that_impl(input)

--- a/cvlr-macros/src/lib.rs
+++ b/cvlr-macros/src/lib.rs
@@ -193,3 +193,134 @@ pub fn cvlr_assert_that(input: TokenStream) -> TokenStream {
 pub fn cvlr_assert_all(input: TokenStream) -> TokenStream {
     assert_that::assert_all_impl(input)
 }
+
+/// Assume a condition using a DSL syntax (analogous to `cvlr_assert_that!`)
+///
+/// This macro provides the same DSL syntax as `cvlr_assert_that!` but expands to
+/// `cvlr_assume_*` macros instead of `cvlr_assert_*` macros.
+///
+/// # Syntax
+///
+/// The macro accepts either:
+/// - **Unguarded expression**: `cvlr_assume_that!(condition)`
+/// - **Guarded expression**: `cvlr_assume_that!(if guard { condition })`
+///
+/// The `condition` can be:
+/// - A comparison: `a < b`, `x >= y`, `p == q`, etc.
+/// - A boolean expression: `flag`, `x > 0 && y < 10`, etc.
+///
+/// # Examples
+///
+/// ## Unguarded comparisons
+///
+/// ```rust,no_run
+/// use cvlr_macros::cvlr_assume_that;
+///
+/// let x = 5;
+/// let y = 10;
+///
+/// cvlr_assume_that!(x < y);        // expands to cvlr_assume_lt!(x, y)
+/// cvlr_assume_that!(x <= y);       // expands to cvlr_assume_le!(x, y)
+/// cvlr_assume_that!(x > 0);        // expands to cvlr_assume_gt!(x, 0)
+/// cvlr_assume_that!(x >= 0);       // expands to cvlr_assume_ge!(x, 0)
+/// cvlr_assume_that!(x == 5);       // expands to cvlr_assume_eq!(x, 5)
+/// cvlr_assume_that!(x != 0);       // expands to cvlr_assume_ne!(x, 0)
+/// ```
+///
+/// ## Guarded comparisons
+///
+/// ```rust,no_run
+/// use cvlr_macros::cvlr_assume_that;
+///
+/// let flag = true;
+/// let a = 1;
+/// let b = 2;
+///
+/// // Assume a < b only if flag is true
+/// cvlr_assume_that!(if flag { a < b });  // expands to: if flag { cvlr_assume_lt!(a, b); }
+/// ```
+///
+/// ## Boolean expressions
+///
+/// ```rust,no_run
+/// use cvlr_macros::cvlr_assume_that;
+///
+/// let flag = true;
+/// let x = 5;
+/// let y = 3;
+///
+/// // Unguarded boolean
+/// cvlr_assume_that!(flag);                    // expands to cvlr_assume!(flag)
+/// cvlr_assume_that!(x > 0 && y < 10);         // expands to cvlr_assume!(x > 0 && y < 10)
+///
+/// // Guarded boolean
+/// cvlr_assume_that!(if flag { x > 0 });       // expands to: if flag { cvlr_assume!(x > 0); }
+/// ```
+///
+/// # Expansion
+///
+/// The macro automatically detects comparison operators and expands to the
+/// appropriate assume macro:
+///
+/// - Comparisons (`<`, `<=`, `>`, `>=`, `==`, `!=`) expand to `cvlr_assume_<op>!`
+/// - For guarded expressions, the assume is wrapped in an `if` block
+/// - Boolean expressions expand to `cvlr_assume!`
+#[proc_macro]
+pub fn cvlr_assume_that(input: TokenStream) -> TokenStream {
+    assert_that::assume_that_impl(input)
+}
+
+/// Assume multiple conditions using the same DSL syntax as `cvlr_assume_that!`
+///
+/// This macro takes a list of DSL expressions (same syntax as `cvlr_assume_that!`)
+/// and expands directly to the underlying `cvlr_assume_*` macros. Expressions can be
+/// separated by either commas (`,`) or semicolons (`;`).
+///
+/// # Syntax
+///
+/// Expressions can be separated by commas or semicolons:
+/// - `cvlr_assume_all!(expr1, expr2, expr3);`
+/// - `cvlr_assume_all!(expr1; expr2; expr3);`
+/// - `cvlr_assume_all!(expr1, expr2; expr3);`  // Mixed separators are also allowed
+///
+/// Each expression follows the same syntax as `cvlr_assume_that!`:
+/// - Unguarded: `condition`
+/// - Guarded: `if guard { condition }`
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use cvlr_macros::cvlr_assume_all;
+///
+/// let x = 5;
+/// let y = 10;
+/// let c = true;
+///
+/// // Multiple unguarded assumptions
+/// cvlr_assume_all!(x > 0, y < 20, x < y);
+///
+/// // Mixed guarded and unguarded
+/// cvlr_assume_all!(x > 0, if c { x < y });
+///
+/// // Using semicolons
+/// cvlr_assume_all!(x > 0; y < 20; if c { x < y });
+/// ```
+///
+/// # Expansion
+///
+/// This macro expands directly to the underlying assume macros:
+///
+/// ```text
+/// // Input:
+/// cvlr_assume_all!(x > 0, if c { x < y });
+///
+/// // Expands to:
+/// ::cvlr::asserts::cvlr_assume_gt!(x, 0);
+/// if c {
+///     ::cvlr::asserts::cvlr_assume_lt!(x, y);
+/// }
+/// ```
+#[proc_macro]
+pub fn cvlr_assume_all(input: TokenStream) -> TokenStream {
+    assert_that::assume_all_impl(input)
+}

--- a/cvlr-macros/src/lib.rs
+++ b/cvlr-macros/src/lib.rs
@@ -9,8 +9,7 @@ mod mock;
 /// # Example
 ///
 /// ```
-/// use cvlr_asserts::cvlr_assert;
-/// use cvlr_macros::rule;
+/// use cvlr::prelude::*;
 /// #[rule]
 /// fn foo()  {
 ///    cvlr_assert!(false);

--- a/cvlr-macros/src/lib.rs
+++ b/cvlr-macros/src/lib.rs
@@ -8,7 +8,7 @@ mod mock;
 ///
 /// # Example
 ///
-/// ```
+/// ```rust,no_run
 /// use cvlr::prelude::*;
 /// #[rule]
 /// fn foo()  {
@@ -58,7 +58,7 @@ pub fn mock_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ## Unguarded comparisons
 ///
-/// ```rust
+/// ```rust,no_run
 /// use cvlr_macros::cvlr_assert_that;
 ///
 /// let x = 5;
@@ -74,12 +74,15 @@ pub fn mock_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ## Guarded comparisons
 ///
-/// ```rust
+/// ```rust,no_run
 /// use cvlr_macros::cvlr_assert_that;
 ///
 /// let flag = true;
 /// let a = 1;
 /// let b = 2;
+/// let x = 5;
+/// let y = 10;
+/// let z = 15;
 ///
 /// // Assert b < a only if flag is true
 /// cvlr_assert_that!(if flag { a < b });  // expands to cvlr_assert_lt_if!(flag, a, b)
@@ -88,12 +91,13 @@ pub fn mock_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ## Boolean expressions
 ///
-/// ```rust
+/// ```rust,no_run
 /// use cvlr_macros::cvlr_assert_that;
 ///
 /// let flag = true;
 /// let x = 5;
 /// let y = 3;
+/// let z = 7;
 ///
 /// // Unguarded boolean
 /// cvlr_assert_that!(flag);                    // expands to cvlr_assert!(flag)
@@ -106,13 +110,16 @@ pub fn mock_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ## Complex expressions
 ///
-/// ```rust
+/// ```rust,no_run
 /// use cvlr_macros::cvlr_assert_that;
 ///
 /// let a = 1;
 /// let c = 3;
 /// let d = 4;
 /// let p = 5;
+/// let x = 5;
+/// let y = 3;
+/// let z = 10;
 ///
 /// // Complex guard and condition
 /// cvlr_assert_that!(if a > c { d < p });      // expands to cvlr_assert_lt_if!(a > c, d, p)
@@ -139,11 +146,10 @@ pub fn cvlr_assert_that(input: TokenStream) -> TokenStream {
 ///
 /// # Syntax
 ///
-/// ```rust
-/// cvlr_assert_all!(expr1, expr2, expr3);
-/// cvlr_assert_all!(expr1; expr2; expr3);
-/// cvlr_assert_all!(expr1, expr2; expr3);  // Mixed separators are also allowed
-/// ```
+/// Expressions can be separated by commas or semicolons:
+/// - `cvlr_assert_all!(expr1, expr2, expr3);`
+/// - `cvlr_assert_all!(expr1; expr2; expr3);`
+/// - `cvlr_assert_all!(expr1, expr2; expr3);`  // Mixed separators are also allowed
 ///
 /// Each expression follows the same syntax as `cvlr_assert_that!`:
 /// - Unguarded: `condition`
@@ -151,7 +157,7 @@ pub fn cvlr_assert_that(input: TokenStream) -> TokenStream {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```rust,no_run
 /// use cvlr_macros::cvlr_assert_all;
 ///
 /// let x = 5;
@@ -173,15 +179,15 @@ pub fn cvlr_assert_that(input: TokenStream) -> TokenStream {
 ///
 /// # Expansion
 ///
-/// This macro expands to multiple `cvlr_assert_that!` calls:
+/// This macro expands directly to the underlying assertion macros (not to `cvlr_assert_that!` calls):
 ///
-/// ```rust
+/// ```text
 /// // Input:
 /// cvlr_assert_all!(x > 0, if c { x < y });
 ///
 /// // Expands to:
-/// cvlr_assert_that!(x > 0);
-/// cvlr_assert_that!(if c { x < y });
+/// ::cvlr::asserts::cvlr_assert_gt!(x, 0);
+/// ::cvlr::asserts::cvlr_assert_lt_if!(c, x, y);
 /// ```
 #[proc_macro]
 pub fn cvlr_assert_all(input: TokenStream) -> TokenStream {

--- a/cvlr-macros/src/lib.rs
+++ b/cvlr-macros/src/lib.rs
@@ -2,6 +2,7 @@ use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::{parse_macro_input, parse_quote, ItemFn};
 
+mod assert_that;
 mod mock;
 /// Mark a method as a CVT rule
 ///
@@ -36,4 +37,9 @@ pub fn rule(_attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn mock_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
     mock::mock_fn_impl(attr, item)
+}
+
+#[proc_macro]
+pub fn cvlr_assert_that(input: TokenStream) -> TokenStream {
+    assert_that::assert_that_impl(input)
 }

--- a/cvlr-macros/src/lib.rs
+++ b/cvlr-macros/src/lib.rs
@@ -130,3 +130,60 @@ pub fn mock_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn cvlr_assert_that(input: TokenStream) -> TokenStream {
     assert_that::assert_that_impl(input)
 }
+
+/// Assert multiple conditions using the same DSL syntax as `cvlr_assert_that!`
+///
+/// This macro takes a list of DSL expressions (same syntax as `cvlr_assert_that!`)
+/// and expands to multiple calls to `cvlr_assert_that!`. Expressions can be
+/// separated by either commas (`,`) or semicolons (`;`).
+///
+/// # Syntax
+///
+/// ```rust
+/// cvlr_assert_all!(expr1, expr2, expr3);
+/// cvlr_assert_all!(expr1; expr2; expr3);
+/// cvlr_assert_all!(expr1, expr2; expr3);  // Mixed separators are also allowed
+/// ```
+///
+/// Each expression follows the same syntax as `cvlr_assert_that!`:
+/// - Unguarded: `condition`
+/// - Guarded: `if guard { condition }`
+///
+/// # Examples
+///
+/// ```rust
+/// use cvlr_macros::cvlr_assert_all;
+///
+/// let x = 5;
+/// let y = 10;
+/// let c = true;
+///
+/// // Multiple unguarded assertions
+/// cvlr_assert_all!(x > 0, y < 20, x < y);
+///
+/// // Mixed guarded and unguarded
+/// cvlr_assert_all!(x > 0, if c { x < y });
+///
+/// // Using semicolons
+/// cvlr_assert_all!(x > 0; y < 20; if c { x < y });
+///
+/// // Mixed separators
+/// cvlr_assert_all!(x > 0, y < 20; if c { x < y });
+/// ```
+///
+/// # Expansion
+///
+/// This macro expands to multiple `cvlr_assert_that!` calls:
+///
+/// ```rust
+/// // Input:
+/// cvlr_assert_all!(x > 0, if c { x < y });
+///
+/// // Expands to:
+/// cvlr_assert_that!(x > 0);
+/// cvlr_assert_that!(if c { x < y });
+/// ```
+#[proc_macro]
+pub fn cvlr_assert_all(input: TokenStream) -> TokenStream {
+    assert_that::assert_all_impl(input)
+}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_all.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_all.expanded.rs
@@ -1,0 +1,420 @@
+use cvlr_macros::cvlr_assert_all;
+pub fn test_assert_all_comma_separated() {
+    let x = 5;
+    let y = 10;
+    let z = 15;
+    let a = 1;
+    let b = 2;
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assert y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = z;
+        let rhs = x;
+        ::cvlr_log::cvlr_log("_", &("assert z > x"));
+        ::cvlr_log::cvlr_log("z", &(lhs));
+        ::cvlr_log::cvlr_log("x", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assert a < b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = 5;
+        ::cvlr_log::cvlr_log("_", &("assert x == 5"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("5", &(rhs));
+        {
+            let c_ = lhs == rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = y;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert y != 0"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs != rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+}
+pub fn test_assert_all_semicolon_separated() {
+    let x = 5;
+    let y = 10;
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assert y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assert x < y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+}
+pub fn test_assert_all_mixed_separators() {
+    let x = 5;
+    let y = 10;
+    let flag = true;
+    let c = 3;
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assert y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let guard = flag;
+        ::cvlr_log::cvlr_log("_", &("assert if flag { x < y }"));
+        ::cvlr_log::cvlr_log("flag", &(guard));
+        if guard {
+            let lhs = x;
+            let rhs = y;
+            ::cvlr_log::cvlr_log("x", &(lhs));
+            ::cvlr_log::cvlr_log("y", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assert y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let guard = flag;
+        ::cvlr_log::cvlr_log("_", &("assert if flag { c < y }"));
+        ::cvlr_log::cvlr_log("flag", &(guard));
+        if guard {
+            let lhs = c;
+            let rhs = y;
+            ::cvlr_log::cvlr_log("c", &(lhs));
+            ::cvlr_log::cvlr_log("y", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+}
+pub fn test_assert_all_guarded() {
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    let x = 5;
+    let y = 10;
+    {
+        let guard = flag;
+        ::cvlr_log::cvlr_log("_", &("assert if flag { a < b }"));
+        ::cvlr_log::cvlr_log("flag", &(guard));
+        if guard {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = x > 0;
+        ::cvlr_log::cvlr_log("_", &("assert if x > 0 { y < 20 }"));
+        ::cvlr_log::cvlr_log("x > 0", &(guard));
+        if guard {
+            let lhs = y;
+            let rhs = 20;
+            ::cvlr_log::cvlr_log("y", &(lhs));
+            ::cvlr_log::cvlr_log("20", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = flag;
+        ::cvlr_log::cvlr_log("_", &("assert if flag { a < b }"));
+        ::cvlr_log::cvlr_log("flag", &(guard));
+        if guard {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = x > 0;
+        ::cvlr_log::cvlr_log("_", &("assert if x > 0 { y < 20 }"));
+        ::cvlr_log::cvlr_log("x > 0", &(guard));
+        if guard {
+            let lhs = y;
+            let rhs = 20;
+            ::cvlr_log::cvlr_log("y", &(lhs));
+            ::cvlr_log::cvlr_log("20", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+}
+pub fn test_assert_all_mixed_guarded_unguarded() {
+    let x = 5;
+    let y = 10;
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let guard = flag;
+        ::cvlr_log::cvlr_log("_", &("assert if flag { x < y }"));
+        ::cvlr_log::cvlr_log("flag", &(guard));
+        if guard {
+            let lhs = x;
+            let rhs = y;
+            ::cvlr_log::cvlr_log("x", &(lhs));
+            ::cvlr_log::cvlr_log("y", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = flag;
+        ::cvlr_log::cvlr_log("_", &("assert if flag { a < b }"));
+        ::cvlr_log::cvlr_log("flag", &(guard));
+        if guard {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let lhs = y;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert y > 0"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let guard = flag;
+        ::cvlr_log::cvlr_log("_", &("assert if flag { a < b }"));
+        ::cvlr_log::cvlr_log("flag", &(guard));
+        if guard {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assert y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+}
+pub fn test_assert_all_boolean_expressions() {
+    let flag = true;
+    let x = 5;
+    let y = 3;
+    let z = 7;
+    {
+        let c_ = flag;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = x > 0 && y < 10;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let guard = flag;
+        ::cvlr_log::cvlr_log("_", &("assert if flag { x > 0 }"));
+        ::cvlr_log::cvlr_log("flag", &(guard));
+        if guard {
+            let lhs = x;
+            let rhs = 0;
+            ::cvlr_log::cvlr_log("x", &(lhs));
+            ::cvlr_log::cvlr_log("0", &(rhs));
+            {
+                let c_ = lhs > rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    if x > 0 {
+        {
+            let c_ = y > 0 && z < 10;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    }
+}
+pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_all.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_all.rs
@@ -1,0 +1,70 @@
+use cvlr_macros::cvlr_assert_all;
+
+pub fn test_assert_all_comma_separated() {
+    let x = 5;
+    let y = 10;
+    let z = 15;
+    let a = 1;
+    let b = 2;
+
+    // Multiple unguarded comparisons with commas
+    cvlr_assert_all!(x > 0, y < 20, z > x);
+    cvlr_assert_all!(a < b, x == 5, y != 0);
+}
+
+pub fn test_assert_all_semicolon_separated() {
+    let x = 5;
+    let y = 10;
+
+    // Multiple assertions with semicolons
+    cvlr_assert_all!(x > 0; y < 20; x < y);
+}
+
+pub fn test_assert_all_mixed_separators() {
+    let x = 5;
+    let y = 10;
+    let flag = true;
+    let c = 3;
+
+    // Mixed separators
+    cvlr_assert_all!(x > 0, y < 20; if flag { x < y });
+    cvlr_assert_all!(x > 0; y < 20, if flag { c < y });
+}
+
+pub fn test_assert_all_guarded() {
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    let x = 5;
+    let y = 10;
+
+    // Multiple guarded assertions
+    cvlr_assert_all!(if flag { a < b }, if x > 0 { y < 20 });
+    cvlr_assert_all!(if flag { a < b }; if x > 0 { y < 20 });
+}
+
+pub fn test_assert_all_mixed_guarded_unguarded() {
+    let x = 5;
+    let y = 10;
+    let flag = true;
+    let a = 1;
+    let b = 2;
+
+    // Mixed guarded and unguarded
+    cvlr_assert_all!(x > 0, if flag { x < y });
+    cvlr_assert_all!(if flag { a < b }, y > 0);
+    cvlr_assert_all!(x > 0, if flag { a < b }, y < 20);
+}
+
+pub fn test_assert_all_boolean_expressions() {
+    let flag = true;
+    let x = 5;
+    let y = 3;
+    let z = 7;
+
+    // Boolean expressions
+    cvlr_assert_all!(flag, x > 0 && y < 10);
+    cvlr_assert_all!(if flag { x > 0 }, if x > 0 { y > 0 && z < 10 });
+}
+
+pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_booleans.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_booleans.expanded.rs
@@ -1,0 +1,75 @@
+use cvlr_macros::cvlr_assert_that;
+pub fn test() {
+    let flag = true;
+    let x = 5;
+    let y = 3;
+    let a = true;
+    let b = false;
+    let condition = false;
+    let guard = true;
+    let z = 7;
+    let error = false;
+    let test = true;
+    let c = true;
+    {
+        let c_ = flag;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = x > 0 && y < 10;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = a || b;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = !condition;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let lhs = x + y;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert x + y > 0"));
+        ::cvlr_log::cvlr_log("x + y", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    if guard {
+        {
+            let c_ = condition;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    }
+    if x > 0 {
+        {
+            let c_ = y > 0 && z < 10;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    }
+    if flag {
+        {
+            let c_ = !error;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    }
+    if test {
+        {
+            let c_ = (a || b) && c;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    }
+}
+fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_booleans.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_booleans.rs
@@ -21,10 +21,10 @@ pub fn test() {
     cvlr_assert_that!(x + y > 0);
 
     // Guarded boolean expressions
-    cvlr_assert_that!(guard => condition);
-    cvlr_assert_that!(x > 0 => y > 0 && z < 10);
-    cvlr_assert_that!(flag => !error);
-    cvlr_assert_that!(test => (a || b) && c);
+    cvlr_assert_that!(if guard { condition });
+    cvlr_assert_that!(if x > 0 { y > 0 && z < 10 });
+    cvlr_assert_that!(if flag { !error });
+    cvlr_assert_that!(if test { (a || b) && c });
 }
 
 fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_booleans.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_booleans.rs
@@ -1,0 +1,30 @@
+use cvlr_macros::cvlr_assert_that;
+
+pub fn test() {
+    let flag = true;
+    let x = 5;
+    let y = 3;
+    let a = true;
+    let b = false;
+    let condition = false;
+    let guard = true;
+    let z = 7;
+    let error = false;
+    let test = true;
+    let c = true;
+
+    // Unguarded boolean expressions
+    cvlr_assert_that!(flag);
+    cvlr_assert_that!(x > 0 && y < 10);
+    cvlr_assert_that!(a || b);
+    cvlr_assert_that!(!condition);
+    cvlr_assert_that!(x + y > 0);
+
+    // Guarded boolean expressions
+    cvlr_assert_that!(guard => condition);
+    cvlr_assert_that!(x > 0 => y > 0 && z < 10);
+    cvlr_assert_that!(flag => !error);
+    cvlr_assert_that!(test => (a || b) && c);
+}
+
+fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_comparisons.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_comparisons.expanded.rs
@@ -1,0 +1,109 @@
+use cvlr_macros::cvlr_assert_that;
+pub fn test_comparisons() {
+    let a = 1;
+    let b = 2;
+    let x = 3;
+    let y = 4;
+    let p = 5;
+    let q = 6;
+    let m = 7;
+    let n = 8;
+    let c = 9;
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assert a < b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assert x <= y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        {
+            let c_ = lhs <= rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = p;
+        let rhs = q;
+        ::cvlr_log::cvlr_log("_", &("assert p > q"));
+        ::cvlr_log::cvlr_log("p", &(lhs));
+        ::cvlr_log::cvlr_log("q", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = m;
+        let rhs = n;
+        ::cvlr_log::cvlr_log("_", &("assert m >= n"));
+        ::cvlr_log::cvlr_log("m", &(lhs));
+        ::cvlr_log::cvlr_log("n", &(rhs));
+        {
+            let c_ = lhs >= rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assert x == y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        {
+            let c_ = lhs == rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assert a != b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        {
+            let c_ = lhs != rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x + 1;
+        let rhs = y * 2;
+        ::cvlr_log::cvlr_log("_", &("assert x + 1 < y * 2"));
+        ::cvlr_log::cvlr_log("x + 1", &(lhs));
+        ::cvlr_log::cvlr_log("y * 2", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = a;
+        let rhs = c;
+        ::cvlr_log::cvlr_log("_", &("assert a > c"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("c", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+}
+pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_comparisons.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_comparisons.rs
@@ -1,0 +1,27 @@
+use cvlr_macros::cvlr_assert_that;
+
+pub fn test_comparisons() {
+    let a = 1;
+    let b = 2;
+    let x = 3;
+    let y = 4;
+    let p = 5;
+    let q = 6;
+    let m = 7;
+    let n = 8;
+    let c = 9;
+
+    // Unguarded comparisons - all operators
+    cvlr_assert_that!(a < b);
+    cvlr_assert_that!(x <= y);
+    cvlr_assert_that!(p > q);
+    cvlr_assert_that!(m >= n);
+    cvlr_assert_that!(x == y);
+    cvlr_assert_that!(a != b);
+
+    // With expressions
+    cvlr_assert_that!(x + 1 < y * 2);
+    cvlr_assert_that!(a > c);
+}
+
+pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_guarded_comparisons.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_guarded_comparisons.expanded.rs
@@ -18,7 +18,7 @@ pub fn test_guarded_comparisons() {
     let n = 10;
     {
         let guard = flag;
-        ::cvlr_log::cvlr_log("_", &("assert flag == > a < b"));
+        ::cvlr_log::cvlr_log("_", &("assert if flag { a < b }"));
         ::cvlr_log::cvlr_log("flag", &(guard));
         if guard {
             let lhs = a;
@@ -34,7 +34,7 @@ pub fn test_guarded_comparisons() {
     };
     {
         let guard = x > 0;
-        ::cvlr_log::cvlr_log("_", &("assert x > 0 == > y <= z"));
+        ::cvlr_log::cvlr_log("_", &("assert if x > 0 { y <= z }"));
         ::cvlr_log::cvlr_log("x > 0", &(guard));
         if guard {
             let lhs = y;
@@ -50,7 +50,7 @@ pub fn test_guarded_comparisons() {
     };
     {
         let guard = cond;
-        ::cvlr_log::cvlr_log("_", &("assert cond == > p > q"));
+        ::cvlr_log::cvlr_log("_", &("assert if cond { p > q }"));
         ::cvlr_log::cvlr_log("cond", &(guard));
         if guard {
             let lhs = p;
@@ -66,7 +66,7 @@ pub fn test_guarded_comparisons() {
     };
     {
         let guard = guard;
-        ::cvlr_log::cvlr_log("_", &("assert guard == > m >= n"));
+        ::cvlr_log::cvlr_log("_", &("assert if guard { m >= n }"));
         ::cvlr_log::cvlr_log("guard", &(guard));
         if guard {
             let lhs = m;
@@ -82,7 +82,7 @@ pub fn test_guarded_comparisons() {
     };
     {
         let guard = test;
-        ::cvlr_log::cvlr_log("_", &("assert test == > x == y"));
+        ::cvlr_log::cvlr_log("_", &("assert if test { x == y }"));
         ::cvlr_log::cvlr_log("test", &(guard));
         if guard {
             let lhs = x;
@@ -98,7 +98,7 @@ pub fn test_guarded_comparisons() {
     };
     {
         let guard = check;
-        ::cvlr_log::cvlr_log("_", &("assert check == > a != b"));
+        ::cvlr_log::cvlr_log("_", &("assert if check { a != b }"));
         ::cvlr_log::cvlr_log("check", &(guard));
         if guard {
             let lhs = a;
@@ -114,7 +114,7 @@ pub fn test_guarded_comparisons() {
     };
     {
         let guard = a > c;
-        ::cvlr_log::cvlr_log("_", &("assert a > c == > d < p"));
+        ::cvlr_log::cvlr_log("_", &("assert if a > c { d < p }"));
         ::cvlr_log::cvlr_log("a > c", &(guard));
         if guard {
             let lhs = d;
@@ -130,7 +130,7 @@ pub fn test_guarded_comparisons() {
     };
     {
         let guard = x + 1 > 0;
-        ::cvlr_log::cvlr_log("_", &("assert x + 1 > 0 == > y * 2 < z"));
+        ::cvlr_log::cvlr_log("_", &("assert if x + 1 > 0 { y * 2 < z }"));
         ::cvlr_log::cvlr_log("x + 1 > 0", &(guard));
         if guard {
             let lhs = y * 2;

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_guarded_comparisons.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_guarded_comparisons.expanded.rs
@@ -1,0 +1,148 @@
+use cvlr_macros::cvlr_assert_that;
+pub fn test_guarded_comparisons() {
+    let flag = true;
+    let cond = false;
+    let guard = true;
+    let test = true;
+    let check = false;
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    let p = 5;
+    let q = 6;
+    let x = 6;
+    let y = 7;
+    let z = 8;
+    let m = 9;
+    let n = 10;
+    {
+        let guard = flag;
+        ::cvlr_log::cvlr_log("_", &("assert flag == > a < b"));
+        ::cvlr_log::cvlr_log("flag", &(guard));
+        if guard {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = x > 0;
+        ::cvlr_log::cvlr_log("_", &("assert x > 0 == > y <= z"));
+        ::cvlr_log::cvlr_log("x > 0", &(guard));
+        if guard {
+            let lhs = y;
+            let rhs = z;
+            ::cvlr_log::cvlr_log("y", &(lhs));
+            ::cvlr_log::cvlr_log("z", &(rhs));
+            {
+                let c_ = lhs <= rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = cond;
+        ::cvlr_log::cvlr_log("_", &("assert cond == > p > q"));
+        ::cvlr_log::cvlr_log("cond", &(guard));
+        if guard {
+            let lhs = p;
+            let rhs = q;
+            ::cvlr_log::cvlr_log("p", &(lhs));
+            ::cvlr_log::cvlr_log("q", &(rhs));
+            {
+                let c_ = lhs > rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = guard;
+        ::cvlr_log::cvlr_log("_", &("assert guard == > m >= n"));
+        ::cvlr_log::cvlr_log("guard", &(guard));
+        if guard {
+            let lhs = m;
+            let rhs = n;
+            ::cvlr_log::cvlr_log("m", &(lhs));
+            ::cvlr_log::cvlr_log("n", &(rhs));
+            {
+                let c_ = lhs >= rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = test;
+        ::cvlr_log::cvlr_log("_", &("assert test == > x == y"));
+        ::cvlr_log::cvlr_log("test", &(guard));
+        if guard {
+            let lhs = x;
+            let rhs = y;
+            ::cvlr_log::cvlr_log("x", &(lhs));
+            ::cvlr_log::cvlr_log("y", &(rhs));
+            {
+                let c_ = lhs == rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = check;
+        ::cvlr_log::cvlr_log("_", &("assert check == > a != b"));
+        ::cvlr_log::cvlr_log("check", &(guard));
+        if guard {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            {
+                let c_ = lhs != rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = a > c;
+        ::cvlr_log::cvlr_log("_", &("assert a > c == > d < p"));
+        ::cvlr_log::cvlr_log("a > c", &(guard));
+        if guard {
+            let lhs = d;
+            let rhs = p;
+            ::cvlr_log::cvlr_log("d", &(lhs));
+            ::cvlr_log::cvlr_log("p", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+    {
+        let guard = x + 1 > 0;
+        ::cvlr_log::cvlr_log("_", &("assert x + 1 > 0 == > y * 2 < z"));
+        ::cvlr_log::cvlr_log("x + 1 > 0", &(guard));
+        if guard {
+            let lhs = y * 2;
+            let rhs = z;
+            ::cvlr_log::cvlr_log("y * 2", &(lhs));
+            ::cvlr_log::cvlr_log("z", &(rhs));
+            {
+                let c_ = lhs < rhs;
+                ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                ::cvlr_asserts::cvlr_assert_checked(c_);
+            };
+        }
+    };
+}
+pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_guarded_comparisons.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_guarded_comparisons.rs
@@ -1,0 +1,34 @@
+use cvlr_macros::cvlr_assert_that;
+
+pub fn test_guarded_comparisons() {
+    let flag = true;
+    let cond = false;
+    let guard = true;
+    let test = true;
+    let check = false;
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    let p = 5;
+    let q = 6;
+    let x = 6;
+    let y = 7;
+    let z = 8;
+    let m = 9;
+    let n = 10;
+
+    // Guarded comparisons - all operators
+    cvlr_assert_that!(flag => a < b);
+    cvlr_assert_that!(x > 0 => y <= z);
+    cvlr_assert_that!(cond => p > q);
+    cvlr_assert_that!(guard => m >= n);
+    cvlr_assert_that!(test => x == y);
+    cvlr_assert_that!(check => a != b);
+
+    // Complex guards and conditions
+    cvlr_assert_that!(a > c => d < p);
+    cvlr_assert_that!(x + 1 > 0 => y * 2 < z);
+}
+
+pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_guarded_comparisons.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_guarded_comparisons.rs
@@ -19,16 +19,16 @@ pub fn test_guarded_comparisons() {
     let n = 10;
 
     // Guarded comparisons - all operators
-    cvlr_assert_that!(flag => a < b);
-    cvlr_assert_that!(x > 0 => y <= z);
-    cvlr_assert_that!(cond => p > q);
-    cvlr_assert_that!(guard => m >= n);
-    cvlr_assert_that!(test => x == y);
-    cvlr_assert_that!(check => a != b);
+    cvlr_assert_that!(if flag { a < b });
+    cvlr_assert_that!(if x > 0 { y <= z });
+    cvlr_assert_that!(if cond { p > q });
+    cvlr_assert_that!(if guard { m >= n });
+    cvlr_assert_that!(if test { x == y });
+    cvlr_assert_that!(if check { a != b });
 
     // Complex guards and conditions
-    cvlr_assert_that!(a > c => d < p);
-    cvlr_assert_that!(x + 1 > 0 => y * 2 < z);
+    cvlr_assert_that!(if a > c { d < p });
+    cvlr_assert_that!(if x + 1 > 0 { y * 2 < z });
 }
 
 pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assume_all.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assume_all.expanded.rs
@@ -1,0 +1,258 @@
+use cvlr_macros::cvlr_assume_all;
+pub fn test_assume_all_comma_separated() {
+    let x = 5;
+    let y = 10;
+    let z = 15;
+    let a = 1;
+    let b = 2;
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assume y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    {
+        let lhs = z;
+        let rhs = x;
+        ::cvlr_log::cvlr_log("_", &("assume z > x"));
+        ::cvlr_log::cvlr_log("z", &(lhs));
+        ::cvlr_log::cvlr_log("x", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assume a < b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = 5;
+        ::cvlr_log::cvlr_log("_", &("assume x == 5"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("5", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs == rhs);
+    };
+    {
+        let lhs = y;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume y != 0"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs != rhs);
+    };
+}
+pub fn test_assume_all_semicolon_separated() {
+    let x = 5;
+    let y = 10;
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assume y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assume x < y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+}
+pub fn test_assume_all_mixed_separators() {
+    let x = 5;
+    let y = 10;
+    let flag = true;
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assume y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    if flag {
+        {
+            let lhs = x;
+            let rhs = y;
+            ::cvlr_log::cvlr_log("_", &("assume x < y"));
+            ::cvlr_log::cvlr_log("x", &(lhs));
+            ::cvlr_log::cvlr_log("y", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assume y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    if flag {
+        {
+            let lhs = x;
+            let rhs = y;
+            ::cvlr_log::cvlr_log("_", &("assume x < y"));
+            ::cvlr_log::cvlr_log("x", &(lhs));
+            ::cvlr_log::cvlr_log("y", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+}
+pub fn test_assume_all_guarded() {
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    let x = 5;
+    let y = 10;
+    if flag {
+        {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("_", &("assume a < b"));
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    if x > 0 {
+        {
+            let lhs = y;
+            let rhs = 20;
+            ::cvlr_log::cvlr_log("_", &("assume y < 20"));
+            ::cvlr_log::cvlr_log("y", &(lhs));
+            ::cvlr_log::cvlr_log("20", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    if flag {
+        {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("_", &("assume a < b"));
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    if x > 0 {
+        {
+            let lhs = y;
+            let rhs = 20;
+            ::cvlr_log::cvlr_log("_", &("assume y < 20"));
+            ::cvlr_log::cvlr_log("y", &(lhs));
+            ::cvlr_log::cvlr_log("20", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+}
+pub fn test_assume_all_mixed_guarded_unguarded() {
+    let x = 5;
+    let y = 10;
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    if flag {
+        {
+            let lhs = x;
+            let rhs = y;
+            ::cvlr_log::cvlr_log("_", &("assume x < y"));
+            ::cvlr_log::cvlr_log("x", &(lhs));
+            ::cvlr_log::cvlr_log("y", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    if flag {
+        {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("_", &("assume a < b"));
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    {
+        let lhs = y;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume y > 0"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    if flag {
+        {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("_", &("assume a < b"));
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assume y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+}
+pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assume_all.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assume_all.rs
@@ -1,0 +1,58 @@
+use cvlr_macros::cvlr_assume_all;
+
+pub fn test_assume_all_comma_separated() {
+    let x = 5;
+    let y = 10;
+    let z = 15;
+    let a = 1;
+    let b = 2;
+
+    // Multiple unguarded assumptions with commas
+    cvlr_assume_all!(x > 0, y < 20, z > x);
+    cvlr_assume_all!(a < b, x == 5, y != 0);
+}
+
+pub fn test_assume_all_semicolon_separated() {
+    let x = 5;
+    let y = 10;
+
+    // Multiple assumptions with semicolons
+    cvlr_assume_all!(x > 0; y < 20; x < y);
+}
+
+pub fn test_assume_all_mixed_separators() {
+    let x = 5;
+    let y = 10;
+    let flag = true;
+
+    // Mixed separators
+    cvlr_assume_all!(x > 0, y < 20; if flag { x < y });
+    cvlr_assume_all!(x > 0; y < 20, if flag { x < y });
+}
+
+pub fn test_assume_all_guarded() {
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    let x = 5;
+    let y = 10;
+
+    // Multiple guarded assumptions
+    cvlr_assume_all!(if flag { a < b }, if x > 0 { y < 20 });
+    cvlr_assume_all!(if flag { a < b }; if x > 0 { y < 20 });
+}
+
+pub fn test_assume_all_mixed_guarded_unguarded() {
+    let x = 5;
+    let y = 10;
+    let flag = true;
+    let a = 1;
+    let b = 2;
+
+    // Mixed guarded and unguarded
+    cvlr_assume_all!(x > 0, if flag { x < y });
+    cvlr_assume_all!(if flag { a < b }, y > 0);
+    cvlr_assume_all!(x > 0, if flag { a < b }, y < 20);
+}
+
+pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assume_that.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assume_that.expanded.rs
@@ -1,0 +1,124 @@
+use cvlr_macros::cvlr_assume_that;
+pub fn test_assume_comparisons() {
+    let a = 1;
+    let b = 2;
+    let x = 3;
+    let y = 4;
+    let p = 5;
+    let q = 6;
+    let m = 7;
+    let n = 8;
+    let c = 9;
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assume a < b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assume x <= y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs <= rhs);
+    };
+    {
+        let lhs = p;
+        let rhs = q;
+        ::cvlr_log::cvlr_log("_", &("assume p > q"));
+        ::cvlr_log::cvlr_log("p", &(lhs));
+        ::cvlr_log::cvlr_log("q", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = m;
+        let rhs = n;
+        ::cvlr_log::cvlr_log("_", &("assume m >= n"));
+        ::cvlr_log::cvlr_log("m", &(lhs));
+        ::cvlr_log::cvlr_log("n", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs >= rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assume x == y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs == rhs);
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assume a != b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs != rhs);
+    };
+    {
+        let lhs = x + 1;
+        let rhs = y * 2;
+        ::cvlr_log::cvlr_log("_", &("assume x + 1 < y * 2"));
+        ::cvlr_log::cvlr_log("x + 1", &(lhs));
+        ::cvlr_log::cvlr_log("y * 2", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    {
+        let lhs = a;
+        let rhs = c;
+        ::cvlr_log::cvlr_log("_", &("assume a > c"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("c", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+}
+pub fn test_assume_guarded_comparisons() {
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    let x = 5;
+    let y = 10;
+    if flag {
+        {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("_", &("assume a < b"));
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    if x > 0 {
+        {
+            let lhs = y;
+            let rhs = 20;
+            ::cvlr_log::cvlr_log("_", &("assume y <= 20"));
+            ::cvlr_log::cvlr_log("y", &(lhs));
+            ::cvlr_log::cvlr_log("20", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs <= rhs);
+        };
+    }
+}
+pub fn test_assume_booleans() {
+    let flag = true;
+    let x = 5;
+    let y = 3;
+    ::cvlr_asserts::cvlr_assume_checked(flag);
+    ::cvlr_asserts::cvlr_assume_checked(x > 0 && y < 10);
+    if flag {
+        {
+            let lhs = x;
+            let rhs = 0;
+            ::cvlr_log::cvlr_log("_", &("assume x > 0"));
+            ::cvlr_log::cvlr_log("x", &(lhs));
+            ::cvlr_log::cvlr_log("0", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+        };
+    }
+    if x > 0 {
+        ::cvlr_asserts::cvlr_assume_checked(y > 0 && y < 10);
+    }
+}
+pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assume_that.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assume_that.rs
@@ -1,0 +1,53 @@
+use cvlr_macros::cvlr_assume_that;
+
+pub fn test_assume_comparisons() {
+    let a = 1;
+    let b = 2;
+    let x = 3;
+    let y = 4;
+    let p = 5;
+    let q = 6;
+    let m = 7;
+    let n = 8;
+    let c = 9;
+
+    // Unguarded comparisons - all operators
+    cvlr_assume_that!(a < b);
+    cvlr_assume_that!(x <= y);
+    cvlr_assume_that!(p > q);
+    cvlr_assume_that!(m >= n);
+    cvlr_assume_that!(x == y);
+    cvlr_assume_that!(a != b);
+
+    // With expressions
+    cvlr_assume_that!(x + 1 < y * 2);
+    cvlr_assume_that!(a > c);
+}
+
+pub fn test_assume_guarded_comparisons() {
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    let x = 5;
+    let y = 10;
+
+    // Guarded comparisons
+    cvlr_assume_that!(if flag { a < b });
+    cvlr_assume_that!(if x > 0 { y <= 20 });
+}
+
+pub fn test_assume_booleans() {
+    let flag = true;
+    let x = 5;
+    let y = 3;
+
+    // Unguarded boolean expressions
+    cvlr_assume_that!(flag);
+    cvlr_assume_that!(x > 0 && y < 10);
+
+    // Guarded boolean expressions
+    cvlr_assume_that!(if flag { x > 0 });
+    cvlr_assume_that!(if x > 0 { y > 0 && y < 10 });
+}
+
+pub fn main() {}

--- a/cvlr-macros/tests/test_assert_that.rs
+++ b/cvlr-macros/tests/test_assert_that.rs
@@ -1,0 +1,14 @@
+//! Tests for cvlr_assert_that macro
+
+#[test]
+fn test_cvlr_assert_that_macro_expansion() {
+    macrotest::expand("tests/expand/*.rs");
+}
+
+#[test]
+fn test_cvlr_assert_that_compiles() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/expand/test_cvlr_assert_that_comparisons.rs");
+    t.pass("tests/expand/test_cvlr_assert_that_guarded_comparisons.rs");
+    t.pass("tests/expand/test_cvlr_assert_that_booleans.rs");
+}

--- a/cvlr-macros/tests/test_assert_that.rs
+++ b/cvlr-macros/tests/test_assert_that.rs
@@ -1,4 +1,4 @@
-//! Tests for cvlr_assert_that and cvlr_assert_all macros
+//! Tests for cvlr_assert_that, cvlr_assert_all, cvlr_assume_that, and cvlr_assume_all macros
 
 #[test]
 fn test_cvlr_assert_that_macro_expansion() {
@@ -12,4 +12,6 @@ fn test_cvlr_assert_that_compiles() {
     t.pass("tests/expand/test_cvlr_assert_that_guarded_comparisons.rs");
     t.pass("tests/expand/test_cvlr_assert_that_booleans.rs");
     t.pass("tests/expand/test_cvlr_assert_all.rs");
+    t.pass("tests/expand/test_cvlr_assume_that.rs");
+    t.pass("tests/expand/test_cvlr_assume_all.rs");
 }

--- a/cvlr-macros/tests/test_assert_that.rs
+++ b/cvlr-macros/tests/test_assert_that.rs
@@ -1,4 +1,4 @@
-//! Tests for cvlr_assert_that macro
+//! Tests for cvlr_assert_that and cvlr_assert_all macros
 
 #[test]
 fn test_cvlr_assert_that_macro_expansion() {
@@ -11,4 +11,5 @@ fn test_cvlr_assert_that_compiles() {
     t.pass("tests/expand/test_cvlr_assert_that_comparisons.rs");
     t.pass("tests/expand/test_cvlr_assert_that_guarded_comparisons.rs");
     t.pass("tests/expand/test_cvlr_assert_that_booleans.rs");
+    t.pass("tests/expand/test_cvlr_assert_all.rs");
 }

--- a/cvlr/Cargo.toml
+++ b/cvlr/Cargo.toml
@@ -16,6 +16,7 @@ repository.workspace = true
 default = ["cvlr-nondet/std"]
 vacuity = ["cvlr-asserts/vacuity"]
 rt = ["cvlr-asserts/rt", "cvlr-mathint/rt", "cvlr-log/rt", "cvlr-nondet/rt"]
+no-loc = ["cvlr-log/no-loc", "cvlr-asserts/no-loc"]
 
 [dependencies]
 cvlr-asserts = { workspace = true }


### PR DESCRIPTION
A macro with new DSL for conditions:
* `cvlr_assert_that!` . see documentation for new syntax
* `cvlr_assert_all!` applies `cvlr_assert_that!` to a list of conditions separated by `;` or `,`