### PR TITLE
Support for explicit return in cvlr_early_panic

### DIFF
--- a/cvlr-early-panic/Cargo.toml
+++ b/cvlr-early-panic/Cargo.toml
@@ -20,3 +20,7 @@ proc-macro = true
 proc-macro2 = { workspace = true }
 quote = { workspace = true}
 syn = { workspace = true, features = ["visit-mut", "full"] }
+
+[dev-dependencies]
+macrotest = { workspace = true }
+trybuild = { workspace = true }

--- a/cvlr-early-panic/src/lib.rs
+++ b/cvlr-early-panic/src/lib.rs
@@ -1,10 +1,33 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::visit_mut::{self, VisitMut};
-use syn::{parse_macro_input, parse_quote, Expr, ItemFn};
+use syn::{parse_macro_input, parse_quote, Expr, ItemFn, Stmt};
 
 /// Replaces question mark operator by unwrap
 struct EarlyPanic;
+
+impl EarlyPanic {
+    /// Check if an expression is `Err(...)`
+    fn is_err_expr(expr: &Expr) -> bool {
+        match expr {
+            Expr::Call(call) => {
+                // Check if the function is `Err` or `Result::Err` or `std::result::Result::Err`
+                match &*call.func {
+                    Expr::Path(path_expr) => {
+                        let path = &path_expr.path;
+                        // Check if the last segment is "Err"
+                        path.segments
+                            .last()
+                            .map(|seg| seg.ident == "Err")
+                            .unwrap_or(false)
+                    }
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
+}
 
 impl VisitMut for EarlyPanic {
     fn visit_expr_mut(&mut self, node: &mut Expr) {
@@ -18,6 +41,36 @@ impl VisitMut for EarlyPanic {
 
         // -- recurse on other expression types
         visit_mut::visit_expr_mut(self, node);
+    }
+
+    fn visit_stmt_mut(&mut self, node: &mut Stmt) {
+        match node {
+            Stmt::Expr(expr, _) => {
+                // Recurse first to handle nested expressions (including ? operators)
+                visit_mut::visit_expr_mut(self, expr);
+
+                // Check if this expression should panic
+                // Use a temporary immutable reference for pattern matching
+                let is_return_err = {
+                    match expr {
+                        Expr::Return(ret_expr) => {
+                            ret_expr.expr.as_ref().is_some_and(|v| Self::is_err_expr(v))
+                        }
+                        _ => false,
+                    }
+                };
+
+                let is_bare_err = { !matches!(*expr, Expr::Return(_)) && Self::is_err_expr(expr) };
+
+                if is_return_err || is_bare_err {
+                    *node = parse_quote!(panic!(););
+                }
+            }
+            _ => {
+                // Recurse on other statement types
+                visit_mut::visit_stmt_mut(self, node);
+            }
+        }
     }
 }
 

--- a/cvlr-early-panic/tests/expand/test_bare_err.expanded.rs
+++ b/cvlr-early-panic/tests/expand/test_bare_err.expanded.rs
@@ -1,0 +1,20 @@
+use cvlr_early_panic::early_panic;
+fn test_bare_err() -> Result<u64, u64> {
+    ::core::panicking::panic("explicit panic");
+}
+fn test_bare_err_conditional(x: u64) -> Result<u64, u64> {
+    if x > 10 {
+        ::core::panicking::panic("explicit panic");
+    } else {
+        Ok(x)
+    }
+}
+fn test_bare_err_with_question_mark() -> Result<u64, String> {
+    let v = "42".parse::<u64>().unwrap();
+    if v > 100 {
+        ::core::panicking::panic("explicit panic");
+    } else {
+        Ok(v)
+    }
+}
+fn main() {}

--- a/cvlr-early-panic/tests/expand/test_bare_err.rs
+++ b/cvlr-early-panic/tests/expand/test_bare_err.rs
@@ -1,0 +1,27 @@
+use cvlr_early_panic::early_panic;
+
+#[early_panic]
+fn test_bare_err() -> Result<u64, u64> {
+    Err(42)
+}
+
+#[early_panic]
+fn test_bare_err_conditional(x: u64) -> Result<u64, u64> {
+    if x > 10 {
+        Err(42)
+    } else {
+        Ok(x)
+    }
+}
+
+#[early_panic]
+fn test_bare_err_with_question_mark() -> Result<u64, String> {
+    let v = "42".parse::<u64>()?;
+    if v > 100 {
+        Err("too large".to_string())
+    } else {
+        Ok(v)
+    }
+}
+
+fn main() {}

--- a/cvlr-early-panic/tests/expand/test_mixed.expanded.rs
+++ b/cvlr-early-panic/tests/expand/test_mixed.expanded.rs
@@ -1,0 +1,32 @@
+use cvlr_early_panic::early_panic;
+fn test_mixed_question_mark_and_return_err() -> Result<u64, String> {
+    let v = "42".parse::<u64>().unwrap();
+    if v > 100 {
+        ::core::panicking::panic("explicit panic");
+    }
+    Ok(v)
+}
+fn test_mixed_all_patterns() -> Result<u64, String> {
+    let v = "42".parse::<u64>().unwrap();
+    if v == 0 {
+        ::core::panicking::panic("explicit panic");
+    }
+    if v > 100 {
+        ::core::panicking::panic("explicit panic");
+    } else {
+        Ok(v)
+    }
+}
+fn test_complex_nested() -> Result<u64, String> {
+    let a = "10".parse::<u64>().unwrap();
+    if a > 5 {
+        let b = "20".parse::<u64>().unwrap();
+        if b > 15 {
+            ::core::panicking::panic("explicit panic");
+        }
+        Ok(b)
+    } else {
+        ::core::panicking::panic("explicit panic");
+    }
+}
+fn main() {}

--- a/cvlr-early-panic/tests/expand/test_mixed.rs
+++ b/cvlr-early-panic/tests/expand/test_mixed.rs
@@ -1,0 +1,39 @@
+use cvlr_early_panic::early_panic;
+
+#[early_panic]
+fn test_mixed_question_mark_and_return_err() -> Result<u64, String> {
+    let v = "42".parse::<u64>()?;
+    if v > 100 {
+        return Err("too large".to_string());
+    }
+    Ok(v)
+}
+
+#[early_panic]
+fn test_mixed_all_patterns() -> Result<u64, String> {
+    let v = "42".parse::<u64>()?;
+    if v == 0 {
+        return Err("zero".to_string());
+    }
+    if v > 100 {
+        Err("too large".to_string())
+    } else {
+        Ok(v)
+    }
+}
+
+#[early_panic]
+fn test_complex_nested() -> Result<u64, String> {
+    let a = "10".parse::<u64>()?;
+    if a > 5 {
+        let b = "20".parse::<u64>()?;
+        if b > 15 {
+            return Err("both too large".to_string());
+        }
+        Ok(b)
+    } else {
+        Err("a too small".to_string())
+    }
+}
+
+fn main() {}

--- a/cvlr-early-panic/tests/expand/test_option.expanded.rs
+++ b/cvlr-early-panic/tests/expand/test_option.expanded.rs
@@ -1,0 +1,12 @@
+use cvlr_early_panic::early_panic;
+fn test_option_question_mark() -> Option<u64> {
+    let v = Some(42).unwrap();
+    Some(v)
+}
+fn test_option_none() -> Option<u64> {
+    None
+}
+fn test_option_return_none() -> Option<u64> {
+    return None;
+}
+fn main() {}

--- a/cvlr-early-panic/tests/expand/test_question_mark.expanded.rs
+++ b/cvlr-early-panic/tests/expand/test_question_mark.expanded.rs
@@ -1,0 +1,15 @@
+use cvlr_early_panic::early_panic;
+fn test_question_mark() -> Result<u64, String> {
+    let v = "42".parse::<u64>().unwrap();
+    Ok(v)
+}
+fn test_nested_question_mark() -> Result<u64, String> {
+    let v = "42".parse::<u64>().unwrap().checked_add(1).ok_or("overflow").unwrap();
+    Ok(v)
+}
+fn test_multiple_question_marks() -> Result<u64, String> {
+    let a = "10".parse::<u64>().unwrap();
+    let b = "20".parse::<u64>().unwrap();
+    Ok(a + b)
+}
+fn main() {}

--- a/cvlr-early-panic/tests/expand/test_question_mark.rs
+++ b/cvlr-early-panic/tests/expand/test_question_mark.rs
@@ -1,0 +1,22 @@
+use cvlr_early_panic::early_panic;
+
+#[early_panic]
+fn test_question_mark() -> Result<u64, String> {
+    let v = "42".parse::<u64>()?;
+    Ok(v)
+}
+
+#[early_panic]
+fn test_nested_question_mark() -> Result<u64, String> {
+    let v = "42".parse::<u64>()?.checked_add(1).ok_or("overflow")?;
+    Ok(v)
+}
+
+#[early_panic]
+fn test_multiple_question_marks() -> Result<u64, String> {
+    let a = "10".parse::<u64>()?;
+    let b = "20".parse::<u64>()?;
+    Ok(a + b)
+}
+
+fn main() {}

--- a/cvlr-early-panic/tests/expand/test_return_err.expanded.rs
+++ b/cvlr-early-panic/tests/expand/test_return_err.expanded.rs
@@ -1,0 +1,20 @@
+use cvlr_early_panic::early_panic;
+fn test_return_err() -> Result<u64, u64> {
+    ::core::panicking::panic("explicit panic");
+}
+fn test_return_err_conditional(x: u64) -> Result<u64, u64> {
+    if x > 10 {
+        ::core::panicking::panic("explicit panic");
+    }
+    Ok(x)
+}
+fn test_return_err_nested() -> Result<u64, u64> {
+    if true {
+        if false {
+            ::core::panicking::panic("explicit panic");
+        }
+        ::core::panicking::panic("explicit panic");
+    }
+    Ok(0)
+}
+fn main() {}

--- a/cvlr-early-panic/tests/expand/test_return_err.rs
+++ b/cvlr-early-panic/tests/expand/test_return_err.rs
@@ -1,0 +1,27 @@
+use cvlr_early_panic::early_panic;
+
+#[early_panic]
+fn test_return_err() -> Result<u64, u64> {
+    return Err(42);
+}
+
+#[early_panic]
+fn test_return_err_conditional(x: u64) -> Result<u64, u64> {
+    if x > 10 {
+        return Err(42);
+    }
+    Ok(x)
+}
+
+#[early_panic]
+fn test_return_err_nested() -> Result<u64, u64> {
+    if true {
+        if false {
+            return Err(1);
+        }
+        return Err(2);
+    }
+    Ok(0)
+}
+
+fn main() {}

--- a/cvlr-early-panic/tests/test.rs
+++ b/cvlr-early-panic/tests/test.rs
@@ -12,3 +12,28 @@ fn test_one_payload() -> Result<u64, <u64 as FromStr>::Err> {
 fn test_one() {
     let _ = test_one_payload();
 }
+
+#[early_panic]
+fn test_two_payload() -> Result<u64, u64> {
+    Err(42)
+}
+
+#[test]
+#[should_panic]
+fn test_two() {
+    let _ = test_two_payload();
+}
+
+#[early_panic]
+fn test_three_payload(a: u64) -> Result<u64, u64> {
+    if a > 10 {
+        return Err(42);
+    }
+    Ok(a)
+}
+
+#[test]
+#[should_panic]
+fn test_three() {
+    let _ = test_three_payload(11);
+}

--- a/cvlr-early-panic/tests/test_macro_expand.rs
+++ b/cvlr-early-panic/tests/test_macro_expand.rs
@@ -1,0 +1,4 @@
+#[test]
+pub fn expand() {
+    macrotest::expand("tests/expand/*.rs");
+}


### PR DESCRIPTION
The attribute macro `cvlr_early_panic` modifies code to fail early, without graceful error propagation. 
This PR extends it to support code that indicates an error explicitly by returning `Err`