### PR TITLE
Decimal numbers in Cvlr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ members = [
     "cvlr-hook",
     "cvlr-macros",
     "cvlr-fixed",
-    "cvlr-derive"
+    "cvlr-derive",
+    "cvlr-decimal",
 ]
 
 [workspace.package]

--- a/cvlr-decimal/Cargo.toml
+++ b/cvlr-decimal/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "cvlr-decimal"
+description = "Decimal numbers over Certora native integers" 
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+categories.workspace = true
+keywords.workspace = true
+authors.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+
+[features]
+rt = ["cvlr-mathint/rt", "cvlr-nondet/rt", "cvlr-asserts/rt", "cvlr-log/rt"]
+
+[dependencies]
+cvlr-nondet = { workspace = true, default-features = false }
+cvlr-asserts = { workspace = true }
+cvlr-mathint = { workspace = true }
+cvlr-log = { workspace = true }
+
+[dev-dependencies]
+cvlr = { path = "../cvlr", features = ["rt", "no-loc"] }

--- a/cvlr-decimal/src/lib.rs
+++ b/cvlr-decimal/src/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+pub mod native_decimal;
+
+pub use native_decimal::*;

--- a/cvlr-decimal/src/native_decimal.rs
+++ b/cvlr-decimal/src/native_decimal.rs
@@ -1,0 +1,91 @@
+use cvlr_log::{CvlrLog, CvlrLogger};
+use cvlr_mathint::NativeInt;
+use cvlr_nondet::{nondet, Nondet};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub struct NativeDecimal<const D: u32> {
+    val: NativeInt,
+}
+
+impl<const D: u32> NativeDecimal<D> {
+    pub fn new(val: NativeInt) -> Self {
+        Self { val }
+    }
+
+    pub fn as_int(&self) -> NativeInt {
+        self.val
+    }
+}
+
+pub trait AsDecimal<const D: u32> {
+    fn as_decimal(&self) -> NativeDecimal<D>;
+}
+
+impl<const D: u32, T> AsDecimal<D> for T
+where
+    T: Into<NativeInt> + Copy,
+{
+    fn as_decimal(&self) -> NativeDecimal<D> {
+        NativeDecimal::new((*self).into())
+    }
+}
+
+impl<const D: u32> CvlrLog for NativeDecimal<D> {
+    fn log(&self, tag: &str, logger: &mut CvlrLogger) {
+        logger.log_u64_as_dec(tag, self.val.into(), D as u64);
+    }
+}
+
+impl<const D: u32> core::ops::Deref for NativeDecimal<D> {
+    type Target = NativeInt;
+    fn deref(&self) -> &Self::Target {
+        &self.val
+    }
+}
+
+impl<const D: u32> Nondet for NativeDecimal<D> {
+    fn nondet() -> Self {
+        Self::new(nondet::<NativeInt>())
+    }
+}
+
+impl<const D: u32> core::ops::Add<NativeDecimal<D>> for NativeDecimal<D> {
+    type Output = Self;
+    fn add(self, other: NativeDecimal<D>) -> Self::Output {
+        Self::new(self.val + other.val)
+    }
+}
+
+impl<const D: u32, T> core::ops::Add<T> for NativeDecimal<D>
+where
+    T: Into<NativeInt>,
+{
+    type Output = Self;
+    fn add(self, other: T) -> Self::Output {
+        Self::new(self.as_int() + other.into())
+    }
+}
+
+impl<const D: u32> core::ops::Add<NativeDecimal<D>> for NativeInt {
+    type Output = NativeDecimal<D>;
+    fn add(self, other: NativeDecimal<D>) -> Self::Output {
+        Self::Output::new(self + other.as_int())
+    }
+}
+
+impl<const D: u32, T> core::ops::Mul<T> for NativeDecimal<D>
+where
+    T: Into<NativeInt>,
+{
+    type Output = Self;
+    fn mul(self, other: T) -> Self::Output {
+        Self::new(self.as_int() * other.into())
+    }
+}
+
+impl<const D: u32> core::ops::Mul<NativeDecimal<D>> for NativeInt {
+    type Output = NativeDecimal<D>;
+    fn mul(self, other: NativeDecimal<D>) -> Self::Output {
+        Self::Output::new(self * other.as_int())
+    }
+}

--- a/cvlr-decimal/src/native_decimal.rs
+++ b/cvlr-decimal/src/native_decimal.rs
@@ -89,3 +89,175 @@ impl<const D: u32> core::ops::Mul<NativeDecimal<D>> for NativeInt {
         Self::Output::new(self * other.as_int())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn test_new_and_as_int() {
+        let val: NativeInt = 42.into();
+        let decimal: NativeDecimal<2> = NativeDecimal::new(val);
+        assert_eq!(decimal.as_int(), val);
+    }
+
+    #[test]
+    fn test_as_decimal_trait() {
+        // Test with u64
+        let val: u64 = 100;
+        let decimal: NativeDecimal<2> = val.as_decimal();
+        assert_eq!(decimal.as_int(), val);
+
+        // Test with u32
+        let val: u32 = 50;
+        let decimal: NativeDecimal<4> = val.as_decimal();
+        assert_eq!(decimal.as_int(), val);
+
+        // Test with u8
+        let val: u8 = 10;
+        let decimal: NativeDecimal<6> = val.as_decimal();
+        assert_eq!(decimal.as_int(), val);
+
+        // Test with i32
+        let val: i32 = 5;
+        let decimal: NativeDecimal<2> = val.as_decimal();
+        assert_eq!(decimal.as_int(), val);
+    }
+
+    #[test]
+    fn test_addition_native_decimal() {
+        let a: NativeDecimal<2> = NativeDecimal::new(10.into());
+        let b: NativeDecimal<2> = NativeDecimal::new(20.into());
+        let result = a + b;
+        assert_eq!(result.as_int(), 30);
+    }
+
+    #[test]
+    fn test_addition_with_primitive() {
+        let a: NativeDecimal<2> = NativeDecimal::new(10.into());
+        let result = a + 5u64;
+        assert_eq!(result.as_int(), 15);
+
+        let result = a + 3u32;
+        assert_eq!(result.as_int(), 13);
+    }
+
+    #[test]
+    fn test_addition_native_int_with_decimal() {
+        let a: NativeInt = 5.into();
+        let b: NativeDecimal<2> = NativeDecimal::new(10.into());
+        let result: NativeDecimal<2> = a + b;
+        assert_eq!(result.as_int(), 15);
+    }
+
+    #[test]
+    fn test_multiplication_with_primitive() {
+        let a: NativeDecimal<2> = NativeDecimal::new(10.into());
+        let result = a * 3u64;
+        assert_eq!(result.as_int(), 30);
+
+        let result = a * 2u32;
+        assert_eq!(result.as_int(), 20);
+    }
+
+    #[test]
+    fn test_multiplication_native_int_with_decimal() {
+        let a: NativeInt = 5.into();
+        let b: NativeDecimal<2> = NativeDecimal::new(10.into());
+        let result: NativeDecimal<2> = a * b;
+        assert_eq!(result.as_int(), 50);
+    }
+
+    #[test]
+    fn test_comparison_operations() {
+        let a: NativeDecimal<2> = NativeDecimal::new(5.into());
+        let b: NativeDecimal<2> = NativeDecimal::new(10.into());
+        let c: NativeDecimal<2> = NativeDecimal::new(5.into());
+
+        // Equality
+        assert_eq!(a, c);
+        assert_ne!(a, b);
+
+        // Less than
+        assert!(a < b);
+        assert!(!(b < a));
+        assert!(!(a < c));
+
+        // Less than or equal
+        assert!(a <= b);
+        assert!(a <= c);
+        assert!(!(b <= a));
+
+        // Greater than
+        assert!(b > a);
+        assert!(!(a > b));
+        assert!(!(a > c));
+
+        // Greater than or equal
+        assert!(b >= a);
+        assert!(a >= c);
+        assert!(!(a >= b));
+    }
+
+    #[test]
+    fn test_ordering() {
+        let values = vec![
+            NativeDecimal::<2>::new(3.into()),
+            NativeDecimal::<2>::new(1.into()),
+            NativeDecimal::<2>::new(4.into()),
+            NativeDecimal::<2>::new(2.into()),
+        ];
+        let mut sorted = values.clone();
+        sorted.sort();
+        assert_eq!(sorted[0].as_int(), 1);
+        assert_eq!(sorted[1].as_int(), 2);
+        assert_eq!(sorted[2].as_int(), 3);
+        assert_eq!(sorted[3].as_int(), 4);
+    }
+
+    #[test]
+    fn test_clone_and_copy() {
+        let a: NativeDecimal<2> = NativeDecimal::new(42.into());
+        let b = a; // Copy
+        let c = a.clone(); // Clone
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        assert_eq!(b, c);
+    }
+
+    #[test]
+    fn test_deref() {
+        let decimal: NativeDecimal<2> = NativeDecimal::new(100.into());
+        let native_int: &NativeInt = &*decimal;
+        assert_eq!(*native_int, 100);
+    }
+
+    #[test]
+    fn test_different_precision_constants() {
+        let val: u64 = 100;
+        let decimal_2: NativeDecimal<2> = val.as_decimal();
+        let decimal_4: NativeDecimal<4> = val.as_decimal();
+        let decimal_6: NativeDecimal<6> = val.as_decimal();
+
+        // All should have the same underlying value
+        assert_eq!(decimal_2.as_int(), decimal_4.as_int());
+        assert_eq!(decimal_4.as_int(), decimal_6.as_int());
+
+        // But they are different types, so they can't be directly compared
+        // However, we can compare their underlying values
+        assert_eq!(decimal_2.as_int(), decimal_6.as_int());
+    }
+
+    #[test]
+    fn test_chained_operations() {
+        let a: NativeDecimal<2> = NativeDecimal::new(10.into());
+        let b: NativeDecimal<2> = NativeDecimal::new(20.into());
+        let result = a + b + 5u64;
+        assert_eq!(result.as_int(), 35);
+
+        let result = a * 2u64 + b;
+        assert_eq!(result.as_int(), 40);
+    }
+}

--- a/cvlr-log/src/core.rs
+++ b/cvlr-log/src/core.rs
@@ -16,6 +16,7 @@ pub mod rt_decls {
         pub fn CVT_calltrace_print_string(tag: &str, v: &str);
 
         pub fn CVT_calltrace_print_u64_as_fixed(tag: &str, x: u64, y: u64);
+        pub fn CVT_calltrace_print_u64_as_decimal(tag: &str, x: u64, y: u64);
 
         pub fn CVT_calltrace_print_location(file: &str, line: u64);
         pub fn CVT_calltrace_attach_location(file: &str, line: u64);
@@ -50,6 +51,8 @@ mod rt_impls {
     pub extern "C" fn CVT_calltrace_print_i128(_tag: &str, _x: i128) {}
     #[no_mangle]
     pub extern "C" fn CVT_calltrace_print_u64_as_fixed(_tag: &str, _x: u64, _y: u64) {}
+    #[no_mangle]
+    pub extern "C" fn CVT_calltrace_print_u64_as_decimal(_tag: &str, _x: u64, _y: u64) {}
     #[no_mangle]
     pub extern "C" fn CVT_calltrace_print_string(_tag: &str, _v: &str) {}
     #[no_mangle]
@@ -137,6 +140,13 @@ impl CvlrLogger {
     }
 
     #[inline(always)]
+    pub fn log_u64_as_dec(&mut self, t: &str, v: u64, d: u64) {
+        unsafe {
+            CVT_calltrace_print_u64_as_decimal(t, v, d);
+        }
+    }
+
+    #[inline(always)]
     pub fn log_loc(&mut self, file: &str, line: u32) {
         unsafe {
             CVT_calltrace_print_location(file, line as u64);
@@ -182,6 +192,12 @@ pub fn log(v: &str) {
 pub fn log_u64_as_fp(t: &str, v: u64, b: u64) {
     let mut logger = CvlrLogger::new();
     logger.log_u64_as_fp(t, v, b);
+}
+
+#[inline(always)]
+pub fn log_u64_as_dec(t: &str, v: u64, d: u64) {
+    let mut logger = CvlrLogger::new();
+    logger.log_u64_as_dec(t, v, d);
 }
 
 #[inline(always)]


### PR DESCRIPTION
These are similar to cvlr-fixed for fixed point numbers. 

Current application is mostly to log decimal numbers nicely in `clog!`.

Currently supports basic operations to convert from integer types (primitive and native) into decimal, and a few operations that are often used in specifications.