### PR TITLE
New macros: cvlr_eval_that and cvlr_eval_all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cvlr-decimal"
+version = "0.4.1"
+dependencies = [
+ "cvlr",
+ "cvlr-asserts",
+ "cvlr-log",
+ "cvlr-mathint",
+ "cvlr-nondet",
+]
+
+[[package]]
 name = "cvlr-derive"
 version = "0.4.1"
 dependencies = [
@@ -40,9 +51,11 @@ dependencies = [
 name = "cvlr-early-panic"
 version = "0.4.1"
 dependencies = [
+ "macrotest",
  "proc-macro2",
  "quote",
  "syn",
+ "trybuild",
 ]
 
 [[package]]
@@ -92,8 +105,8 @@ dependencies = [
 name = "cvlr-mathint"
 version = "0.4.1"
 dependencies = [
+ "cvlr",
  "cvlr-asserts",
- "cvlr-mathint",
  "cvlr-nondet",
 ]
 

--- a/cvlr-macros/src/lib.rs
+++ b/cvlr-macros/src/lib.rs
@@ -324,3 +324,53 @@ pub fn cvlr_assume_that(input: TokenStream) -> TokenStream {
 pub fn cvlr_assume_all(input: TokenStream) -> TokenStream {
     assert_that::assume_all_impl(input)
 }
+
+/// Evaluate a condition as a boolean expression using the same DSL syntax as `cvlr_assert_that!`
+///
+/// This macro provides the same DSL syntax as `cvlr_assert_that!` but instead of asserting,
+/// it evaluates the condition as a boolean expression. The result is wrapped in its own scope.
+///
+/// # Syntax
+///
+/// The macro accepts either:
+/// - **Unguarded expression**: `cvlr_eval_that!(condition)`
+/// - **Guarded expression**: `cvlr_eval_that!(if guard { condition })`
+///
+/// The `condition` can be:
+/// - A comparison: `a < b`, `x >= y`, `p == q`, etc.
+/// - A boolean expression: `flag`, `x > 0 && y < 10`, etc.
+///
+/// # Examples
+///
+/// ## Unguarded expressions
+///
+/// ```rust,no_run
+/// use cvlr_macros::cvlr_eval_that;
+///
+/// let x = 5;
+/// let y = 10;
+///
+/// let result = cvlr_eval_that!(x < y);        // expands to: { x < y }
+/// let flag = cvlr_eval_that!(x > 0 && y < 20); // expands to: { x > 0 && y < 20 }
+/// ```
+///
+/// ## Guarded expressions
+///
+/// ```rust,no_run
+/// use cvlr_macros::cvlr_eval_that;
+///
+/// let flag = true;
+/// let a = 1;
+/// let b = 2;
+///
+/// let result = cvlr_eval_that!(if flag { a < b });  // expands to: { if flag { a < b } else { true } }
+/// ```
+///
+/// # Expansion
+///
+/// - Unguarded expressions expand to `{ condition }`
+/// - Guarded expressions expand to `{ if guard { condition } else { true } }`
+#[proc_macro]
+pub fn cvlr_eval_that(input: TokenStream) -> TokenStream {
+    assert_that::eval_that_impl(input)
+}

--- a/cvlr-macros/src/lib.rs
+++ b/cvlr-macros/src/lib.rs
@@ -374,3 +374,60 @@ pub fn cvlr_assume_all(input: TokenStream) -> TokenStream {
 pub fn cvlr_eval_that(input: TokenStream) -> TokenStream {
     assert_that::eval_that_impl(input)
 }
+
+/// Evaluate multiple conditions as a boolean expression using the same DSL syntax as `cvlr_eval_that!`
+///
+/// This macro takes a list of DSL expressions (same syntax as `cvlr_eval_that!`)
+/// and evaluates them all, aggregating the results with `&&`. The result is wrapped in its own scope.
+/// Expressions can be separated by either commas (`,`) or semicolons (`;`).
+///
+/// # Syntax
+///
+/// Expressions can be separated by commas or semicolons:
+/// - `cvlr_eval_all!(expr1, expr2, expr3);`
+/// - `cvlr_eval_all!(expr1; expr2; expr3);`
+/// - `cvlr_eval_all!(expr1, expr2; expr3);`  // Mixed separators are also allowed
+///
+/// Each expression follows the same syntax as `cvlr_eval_that!`:
+/// - Unguarded: `condition`
+/// - Guarded: `if guard { condition }`
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use cvlr_macros::cvlr_eval_all;
+///
+/// let x = 5;
+/// let y = 10;
+/// let c = true;
+///
+/// // Multiple unguarded expressions
+/// let result = cvlr_eval_all!(x > 0, y < 20, x < y);
+///
+/// // Mixed guarded and unguarded
+/// let result = cvlr_eval_all!(x > 0, if c { x < y });
+///
+/// // Using semicolons
+/// let result = cvlr_eval_all!(x > 0; y < 20; if c { x < y });
+/// ```
+///
+/// # Expansion
+///
+/// This macro expands to a block that evaluates each expression and aggregates with `&&`:
+///
+/// ```text
+/// // Input:
+/// cvlr_eval_all!(x > 0, y > 0);
+///
+/// // Expands to:
+/// {
+///     let mut __cvlr_eval_all_res = true;
+///     __cvlr_eval_all_res = __cvlr_eval_all_res && { x > 0 };
+///     __cvlr_eval_all_res = __cvlr_eval_all_res && { y > 0 };
+///     __cvlr_eval_all_res
+/// }
+/// ```
+#[proc_macro]
+pub fn cvlr_eval_all(input: TokenStream) -> TokenStream {
+    assert_that::eval_all_impl(input)
+}

--- a/cvlr-macros/tests/expand/test_cvlr_eval_all.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_eval_all.expanded.rs
@@ -1,0 +1,64 @@
+use cvlr_macros::cvlr_eval_all;
+pub fn test_eval_all() {
+    let x = 5;
+    let y = 10;
+    let c = true;
+    let flag = true;
+    let a = 1;
+    let b = 2;
+    let _result1 = {
+        let __cvlr_eval_all_res = true;
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { x > 0 };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { y < 20 };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { x < y };
+        __cvlr_eval_all_res
+    };
+    let _result2 = {
+        let __cvlr_eval_all_res = true;
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { x > 0 };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res
+            && { if c { x < y } else { true } };
+        __cvlr_eval_all_res
+    };
+    let _result3 = {
+        let __cvlr_eval_all_res = true;
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { x > 0 };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { y < 20 };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res
+            && { if c { x < y } else { true } };
+        __cvlr_eval_all_res
+    };
+    let _result4 = {
+        let __cvlr_eval_all_res = true;
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { x > 0 };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { y < 20 };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res
+            && { if c { x < y } else { true } };
+        __cvlr_eval_all_res
+    };
+    let _result5 = {
+        let __cvlr_eval_all_res = true;
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { flag };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { x > 0 && y < 20 };
+        __cvlr_eval_all_res
+    };
+    let _result6 = {
+        let __cvlr_eval_all_res = true;
+        let __cvlr_eval_all_res = __cvlr_eval_all_res
+            && { if flag { x > 0 } else { true } };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res
+            && { if c { y < 20 } else { true } };
+        __cvlr_eval_all_res
+    };
+    let _result7 = {
+        let __cvlr_eval_all_res = true;
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { x + 1 > 0 };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res && { y * 2 < 30 };
+        let __cvlr_eval_all_res = __cvlr_eval_all_res
+            && { if a > 0 { b < 10 } else { true } };
+        __cvlr_eval_all_res
+    };
+}
+pub fn main() {
+    test_eval_all();
+}

--- a/cvlr-macros/tests/expand/test_cvlr_eval_all.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_eval_all.rs
@@ -1,0 +1,36 @@
+use cvlr_macros::cvlr_eval_all;
+
+pub fn test_eval_all() {
+    let x = 5;
+    let y = 10;
+    let c = true;
+    let flag = true;
+    let a = 1;
+    let b = 2;
+
+    // Multiple unguarded expressions
+    let _result1 = cvlr_eval_all!(x > 0, y < 20, x < y);
+
+    // Mixed guarded and unguarded
+    let _result2 = cvlr_eval_all!(x > 0, if c { x < y });
+
+    // Using semicolons
+    let _result3 = cvlr_eval_all!(x > 0; y < 20; if c { x < y });
+
+    // Mixed separators
+    let _result4 = cvlr_eval_all!(x > 0, y < 20; if c { x < y });
+
+    // Boolean expressions
+    let _result5 = cvlr_eval_all!(flag, x > 0 && y < 20);
+
+    // Guarded boolean expressions
+    let _result6 = cvlr_eval_all!(if flag { x > 0 }, if c { y < 20 });
+
+    // Complex expressions
+    let _result7 = cvlr_eval_all!(x + 1 > 0, y * 2 < 30, if a > 0 { b < 10 });
+}
+
+pub fn main() {
+    test_eval_all();
+}
+

--- a/cvlr-macros/tests/expand/test_cvlr_eval_that.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_eval_that.expanded.rs
@@ -1,0 +1,25 @@
+use cvlr_macros::cvlr_eval_that;
+pub fn test_eval_that() {
+    let a = 1;
+    let b = 2;
+    let x = 3;
+    let y = 4;
+    let flag = true;
+    let _result1 = { a < b };
+    let _result2 = { x <= y };
+    let _result3 = { x > 0 };
+    let _result4 = { x >= 0 };
+    let _result5 = { x == 3 };
+    let _result6 = { x != 0 };
+    let _result7 = { flag };
+    let _result8 = { x > 0 && y < 10 };
+    let _result9 = { if flag { a < b } else { true } };
+    let _result10 = { if x > 0 { y <= 10 } else { true } };
+    let _result11 = { if flag { x > 0 } else { true } };
+    let _result12 = { if x > 0 { y > 0 && y < 10 } else { true } };
+    let _result13 = { x + 1 < y * 2 };
+    let _result14 = { if a > 0 { b < 10 } else { true } };
+}
+pub fn main() {
+    test_eval_that();
+}

--- a/cvlr-macros/tests/expand/test_cvlr_eval_that.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_eval_that.rs
@@ -1,0 +1,38 @@
+use cvlr_macros::cvlr_eval_that;
+
+pub fn test_eval_that() {
+    let a = 1;
+    let b = 2;
+    let x = 3;
+    let y = 4;
+    let flag = true;
+
+    // Unguarded comparisons
+    let _result1 = cvlr_eval_that!(a < b);
+    let _result2 = cvlr_eval_that!(x <= y);
+    let _result3 = cvlr_eval_that!(x > 0);
+    let _result4 = cvlr_eval_that!(x >= 0);
+    let _result5 = cvlr_eval_that!(x == 3);
+    let _result6 = cvlr_eval_that!(x != 0);
+
+    // Unguarded boolean expressions
+    let _result7 = cvlr_eval_that!(flag);
+    let _result8 = cvlr_eval_that!(x > 0 && y < 10);
+
+    // Guarded comparisons
+    let _result9 = cvlr_eval_that!(if flag { a < b });
+    let _result10 = cvlr_eval_that!(if x > 0 { y <= 10 });
+
+    // Guarded boolean expressions
+    let _result11 = cvlr_eval_that!(if flag { x > 0 });
+    let _result12 = cvlr_eval_that!(if x > 0 { y > 0 && y < 10 });
+
+    // Complex expressions
+    let _result13 = cvlr_eval_that!(x + 1 < y * 2);
+    let _result14 = cvlr_eval_that!(if a > 0 { b < 10 });
+}
+
+pub fn main() {
+    test_eval_that();
+}
+

--- a/cvlr-macros/tests/test_assert_that.rs
+++ b/cvlr-macros/tests/test_assert_that.rs
@@ -14,4 +14,5 @@ fn test_cvlr_assert_that_compiles() {
     t.pass("tests/expand/test_cvlr_assert_all.rs");
     t.pass("tests/expand/test_cvlr_assume_that.rs");
     t.pass("tests/expand/test_cvlr_assume_all.rs");
+    t.pass("tests/expand/test_cvlr_eval_that.rs");
 }

--- a/cvlr-macros/tests/test_assert_that.rs
+++ b/cvlr-macros/tests/test_assert_that.rs
@@ -15,4 +15,5 @@ fn test_cvlr_assert_that_compiles() {
     t.pass("tests/expand/test_cvlr_assume_that.rs");
     t.pass("tests/expand/test_cvlr_assume_all.rs");
     t.pass("tests/expand/test_cvlr_eval_that.rs");
+    t.pass("tests/expand/test_cvlr_eval_all.rs");
 }


### PR DESCRIPTION
These macros complement corresponding `cvlr_assert_` and `cvlr_assume_` macros. They can be used to evaluate DSL expressions. 