### PR TITLE
Fixes and Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,6 @@ cvlr-log = { path = "cvlr-log", version = "=0.4.1" }
 cvlr-macros = { path = "cvlr-macros", version = "=0.4.1" }
 cvlr-early-panic = { path = "cvlr-early-panic", version = "=0.4.1" }
 cvlr-hook = { path = "cvlr-hook", version = "=0.4.1" }
-cvlr-fixed = { path = "cvlr-fixed", version = "=0.4.1" }
 cvlr-derive = { path = "cvlr-derive", version = "=0.4.1" }
+cvlr-fixed = { path = "cvlr-fixed", version = "=0.4.1" }
+cvlr-decimal = { path = "cvlr-decimal", version = "=0.4.1" }

--- a/cvlr-macros/src/assert_that.rs
+++ b/cvlr-macros/src/assert_that.rs
@@ -60,7 +60,18 @@ pub fn assert_that_impl(input: TokenStream) -> TokenStream {
     expanded.into()
 }
 
+// Helper function to unwrap Expr::Group and Expr::Paren expressions
+fn unwrap_groups(expr: &Expr) -> &Expr {
+    match expr {
+        Expr::Group(group) => unwrap_groups(&group.expr),
+        Expr::Paren(paren) => unwrap_groups(&paren.expr),
+        _ => expr,
+    }
+}
+
 fn analyze_condition(condition: &Expr, guard: Option<&Expr>) -> syn::Result<TokenStream2> {
+    // Unwrap any groups first
+    let condition = unwrap_groups(condition);
     // Check if condition is a binary comparison
     if let Expr::Binary(bin) = condition {
         let op = &bin.op;
@@ -171,6 +182,9 @@ pub fn assert_all_impl(input: TokenStream) -> TokenStream {
 }
 
 fn analyze_assume_condition(condition: &Expr, guard: Option<&Expr>) -> syn::Result<TokenStream2> {
+    // Unwrap any groups first
+    let condition = unwrap_groups(condition);
+
     // Check if condition is a binary comparison
     if let Expr::Binary(bin) = condition {
         let op = &bin.op;
@@ -258,7 +272,6 @@ pub fn assume_all_impl(input: TokenStream) -> TokenStream {
             Err(e) => return e.to_compile_error().into(),
         }
     }
-
     quote! {
         #(#assumptions)*
     }

--- a/cvlr-macros/tests/expand/test_cvlr_assert_all.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_all.expanded.rs
@@ -77,6 +77,78 @@ pub fn test_assert_all_comma_separated() {
             ::cvlr_asserts::cvlr_assert_checked(c_);
         };
     };
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assert y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = z;
+        let rhs = x;
+        ::cvlr_log::cvlr_log("_", &("assert z > x"));
+        ::cvlr_log::cvlr_log("z", &(lhs));
+        ::cvlr_log::cvlr_log("x", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assert a < b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = 5;
+        ::cvlr_log::cvlr_log("_", &("assert x == 5"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("5", &(rhs));
+        {
+            let c_ = lhs == rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = y;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assert y != 0"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        {
+            let c_ = lhs != rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
 }
 pub fn test_assert_all_semicolon_separated() {
     let x = 5;
@@ -416,5 +488,25 @@ pub fn test_assert_all_boolean_expressions() {
             ::cvlr_asserts::cvlr_assert_checked(c_);
         };
     }
+    {
+        let c_ = flag;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = x > 0 && y < 10;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = flag;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = x > 0 && y < 10;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
 }
 pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_all.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_all.rs
@@ -10,6 +10,10 @@ pub fn test_assert_all_comma_separated() {
     // Multiple unguarded comparisons with commas
     cvlr_assert_all!(x > 0, y < 20, z > x);
     cvlr_assert_all!(a < b, x == 5, y != 0);
+
+    // Group-wrapped comparisons
+    cvlr_assert_all!((x > 0), (y < 20), (z > x));
+    cvlr_assert_all!((a < b), ((x == 5)), (y != 0));
 }
 
 pub fn test_assert_all_semicolon_separated() {
@@ -65,6 +69,10 @@ pub fn test_assert_all_boolean_expressions() {
     // Boolean expressions
     cvlr_assert_all!(flag, x > 0 && y < 10);
     cvlr_assert_all!(if flag { x > 0 }, if x > 0 { y > 0 && z < 10 });
+
+    // Group-wrapped boolean expressions
+    cvlr_assert_all!((flag), (x > 0 && y < 10));
+    cvlr_assert_all!((((flag))), ((x > 0 && y < 10)));
 }
 
 pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_booleans.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_booleans.expanded.rs
@@ -43,6 +43,21 @@ pub fn test() {
             ::cvlr_asserts::cvlr_assert_checked(c_);
         };
     };
+    {
+        let c_ = flag;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = x > 0 && y < 10;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
+    {
+        let c_ = a || b;
+        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+        ::cvlr_asserts::cvlr_assert_checked(c_);
+    };
     if guard {
         {
             let c_ = condition;

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_booleans.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_booleans.rs
@@ -20,6 +20,11 @@ pub fn test() {
     cvlr_assert_that!(!condition);
     cvlr_assert_that!(x + y > 0);
 
+    // Group-wrapped boolean expressions
+    cvlr_assert_that!((flag));
+    cvlr_assert_that!((x > 0 && y < 10));
+    cvlr_assert_that!(((a || b)));
+
     // Guarded boolean expressions
     cvlr_assert_that!(if guard { condition });
     cvlr_assert_that!(if x > 0 { y > 0 && z < 10 });

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_comparisons.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_comparisons.expanded.rs
@@ -105,5 +105,101 @@ pub fn test_comparisons() {
             ::cvlr_asserts::cvlr_assert_checked(c_);
         };
     };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assert a < b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assert x > y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = p;
+        let rhs = q;
+        ::cvlr_log::cvlr_log("_", &("assert p <= q"));
+        ::cvlr_log::cvlr_log("p", &(lhs));
+        ::cvlr_log::cvlr_log("q", &(rhs));
+        {
+            let c_ = lhs <= rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = m;
+        let rhs = n;
+        ::cvlr_log::cvlr_log("_", &("assert m >= n"));
+        ::cvlr_log::cvlr_log("m", &(lhs));
+        ::cvlr_log::cvlr_log("n", &(rhs));
+        {
+            let c_ = lhs >= rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assert x == y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        {
+            let c_ = lhs == rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assert a != b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        {
+            let c_ = lhs != rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assert a < b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        {
+            let c_ = lhs < rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assert x > y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        {
+            let c_ = lhs > rhs;
+            ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+            ::cvlr_asserts::cvlr_assert_checked(c_);
+        };
+    };
 }
 pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_that_comparisons.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_that_comparisons.rs
@@ -22,6 +22,18 @@ pub fn test_comparisons() {
     // With expressions
     cvlr_assert_that!(x + 1 < y * 2);
     cvlr_assert_that!(a > c);
+
+    // Group-wrapped comparisons
+    cvlr_assert_that!((a < b));
+    cvlr_assert_that!((x > y));
+    cvlr_assert_that!((p <= q));
+    cvlr_assert_that!((m >= n));
+    cvlr_assert_that!((x == y));
+    cvlr_assert_that!((a != b));
+
+    // Nested groups
+    cvlr_assert_that!(((a < b)));
+    cvlr_assert_that!((((x > y))));
 }
 
 pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assume_all.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assume_all.expanded.rs
@@ -53,6 +53,54 @@ pub fn test_assume_all_comma_separated() {
         ::cvlr_log::cvlr_log("0", &(rhs));
         ::cvlr_asserts::cvlr_assume_checked(lhs != rhs);
     };
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assume y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    {
+        let lhs = z;
+        let rhs = x;
+        ::cvlr_log::cvlr_log("_", &("assume z > x"));
+        ::cvlr_log::cvlr_log("z", &(lhs));
+        ::cvlr_log::cvlr_log("x", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assume a < b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = 5;
+        ::cvlr_log::cvlr_log("_", &("assume x == 5"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("5", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs == rhs);
+    };
+    {
+        let lhs = y;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume y != 0"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs != rhs);
+    };
 }
 pub fn test_assume_all_semicolon_separated() {
     let x = 5;
@@ -192,6 +240,68 @@ pub fn test_assume_all_mixed_guarded_unguarded() {
     let flag = true;
     let a = 1;
     let b = 2;
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    if flag {
+        {
+            let lhs = x;
+            let rhs = y;
+            ::cvlr_log::cvlr_log("_", &("assume x < y"));
+            ::cvlr_log::cvlr_log("x", &(lhs));
+            ::cvlr_log::cvlr_log("y", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    if flag {
+        {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("_", &("assume a < b"));
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    {
+        let lhs = y;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume y > 0"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = 0;
+        ::cvlr_log::cvlr_log("_", &("assume x > 0"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("0", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    if flag {
+        {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("_", &("assume a < b"));
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    {
+        let lhs = y;
+        let rhs = 20;
+        ::cvlr_log::cvlr_log("_", &("assume y < 20"));
+        ::cvlr_log::cvlr_log("y", &(lhs));
+        ::cvlr_log::cvlr_log("20", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
     {
         let lhs = x;
         let rhs = 0;

--- a/cvlr-macros/tests/expand/test_cvlr_assume_all.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assume_all.rs
@@ -10,6 +10,10 @@ pub fn test_assume_all_comma_separated() {
     // Multiple unguarded assumptions with commas
     cvlr_assume_all!(x > 0, y < 20, z > x);
     cvlr_assume_all!(a < b, x == 5, y != 0);
+
+    // Group-wrapped comparisons
+    cvlr_assume_all!((x > 0), (y < 20), (z > x));
+    cvlr_assume_all!((a < b), ((x == 5)), (y != 0));
 }
 
 pub fn test_assume_all_semicolon_separated() {
@@ -53,6 +57,11 @@ pub fn test_assume_all_mixed_guarded_unguarded() {
     cvlr_assume_all!(x > 0, if flag { x < y });
     cvlr_assume_all!(if flag { a < b }, y > 0);
     cvlr_assume_all!(x > 0, if flag { a < b }, y < 20);
+
+    // Mixed with group-wrapped expressions
+    cvlr_assume_all!((x > 0), if flag { (x < y) });
+    cvlr_assume_all!(if flag { (a < b) }, (y > 0));
+    cvlr_assume_all!((x > 0), if flag { ((a < b)) }, (y < 20));
 }
 
 pub fn main() {}

--- a/cvlr-macros/tests/expand/test_cvlr_assume_that.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assume_that.expanded.rs
@@ -73,6 +73,70 @@ pub fn test_assume_comparisons() {
         ::cvlr_log::cvlr_log("c", &(rhs));
         ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
     };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assume a < b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assume x > y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
+    {
+        let lhs = p;
+        let rhs = q;
+        ::cvlr_log::cvlr_log("_", &("assume p <= q"));
+        ::cvlr_log::cvlr_log("p", &(lhs));
+        ::cvlr_log::cvlr_log("q", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs <= rhs);
+    };
+    {
+        let lhs = m;
+        let rhs = n;
+        ::cvlr_log::cvlr_log("_", &("assume m >= n"));
+        ::cvlr_log::cvlr_log("m", &(lhs));
+        ::cvlr_log::cvlr_log("n", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs >= rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assume x == y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs == rhs);
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assume a != b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs != rhs);
+    };
+    {
+        let lhs = a;
+        let rhs = b;
+        ::cvlr_log::cvlr_log("_", &("assume a < b"));
+        ::cvlr_log::cvlr_log("a", &(lhs));
+        ::cvlr_log::cvlr_log("b", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+    };
+    {
+        let lhs = x;
+        let rhs = y;
+        ::cvlr_log::cvlr_log("_", &("assume x > y"));
+        ::cvlr_log::cvlr_log("x", &(lhs));
+        ::cvlr_log::cvlr_log("y", &(rhs));
+        ::cvlr_asserts::cvlr_assume_checked(lhs > rhs);
+    };
 }
 pub fn test_assume_guarded_comparisons() {
     let flag = true;
@@ -98,6 +162,36 @@ pub fn test_assume_guarded_comparisons() {
             ::cvlr_log::cvlr_log("y", &(lhs));
             ::cvlr_log::cvlr_log("20", &(rhs));
             ::cvlr_asserts::cvlr_assume_checked(lhs <= rhs);
+        };
+    }
+    if flag {
+        {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("_", &("assume a < b"));
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
+        };
+    }
+    if x > 0 {
+        {
+            let lhs = y;
+            let rhs = 20;
+            ::cvlr_log::cvlr_log("_", &("assume y <= 20"));
+            ::cvlr_log::cvlr_log("y", &(lhs));
+            ::cvlr_log::cvlr_log("20", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs <= rhs);
+        };
+    }
+    if flag {
+        {
+            let lhs = a;
+            let rhs = b;
+            ::cvlr_log::cvlr_log("_", &("assume a < b"));
+            ::cvlr_log::cvlr_log("a", &(lhs));
+            ::cvlr_log::cvlr_log("b", &(rhs));
+            ::cvlr_asserts::cvlr_assume_checked(lhs < rhs);
         };
     }
 }

--- a/cvlr-macros/tests/expand/test_cvlr_assume_that.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assume_that.rs
@@ -22,6 +22,18 @@ pub fn test_assume_comparisons() {
     // With expressions
     cvlr_assume_that!(x + 1 < y * 2);
     cvlr_assume_that!(a > c);
+
+    // Group-wrapped comparisons
+    cvlr_assume_that!((a < b));
+    cvlr_assume_that!((x > y));
+    cvlr_assume_that!((p <= q));
+    cvlr_assume_that!((m >= n));
+    cvlr_assume_that!((x == y));
+    cvlr_assume_that!((a != b));
+
+    // Nested groups
+    cvlr_assume_that!(((a < b)));
+    cvlr_assume_that!((((x > y))));
 }
 
 pub fn test_assume_guarded_comparisons() {
@@ -34,6 +46,11 @@ pub fn test_assume_guarded_comparisons() {
     // Guarded comparisons
     cvlr_assume_that!(if flag { a < b });
     cvlr_assume_that!(if x > 0 { y <= 20 });
+
+    // Guarded comparisons with groups
+    cvlr_assume_that!(if flag { (a < b) });
+    cvlr_assume_that!(if x > 0 { (y <= 20) });
+    cvlr_assume_that!(if flag { ((a < b)) });
 }
 
 pub fn test_assume_booleans() {

--- a/cvlr/Cargo.toml
+++ b/cvlr/Cargo.toml
@@ -26,3 +26,6 @@ cvlr-nondet = { workspace = true, default-features = false}
 cvlr-macros = { workspace = true }
 cvlr-early-panic = { workspace = true }
 cvlr-hook = { workspace = true }
+cvlr-derive = { workspace = true }
+cvlr-decimal = { workspace = true }
+cvlr-fixed = { workspace = true }

--- a/cvlr/src/lib.rs
+++ b/cvlr/src/lib.rs
@@ -18,6 +18,14 @@ pub mod log {
     pub use cvlr_log::*;
 }
 
+pub mod macros {
+    pub use cvlr_macros::*;
+}
+
+pub mod derive {
+    pub use cvlr_derive::*;
+}
+
 pub mod prelude {
     pub use super::asserts::*;
 
@@ -35,6 +43,13 @@ pub mod prelude {
     pub use cvlr_hook::cvlr_hook_on_exit as hook_on_exit;
     pub use cvlr_macros::mock_fn;
     pub use cvlr_macros::rule;
+
+    pub use cvlr_macros::{
+        cvlr_assert_all, cvlr_assert_that, cvlr_assume_all, cvlr_assume_that, cvlr_eval_all,
+        cvlr_eval_that,
+    };
+
+    pub use cvlr_derive::{CvlrLog, Nondet};
 }
 
 pub use prelude::*;


### PR DESCRIPTION
Allow parentheses and groups in expressions handled by assert_that series of macros

Wire new cvlr sub-crates into cvlr main create to simplify usage