### PR TITLE
Allow statements in `cvlr_predicate!` and related macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "cvlr-macros",
  "cvlr-mathint",
  "cvlr-nondet",
+ "macrotest",
 ]
 
 [[package]]

--- a/cvlr-macros/src/predicate.rs
+++ b/cvlr-macros/src/predicate.rs
@@ -53,7 +53,17 @@ fn extract_context_info(arg: &FnArg) -> syn::Result<(Type, syn::Ident)> {
     }
 }
 
-/// Separates let statements from expressions in function body statements
+/// Returns true if the expression represents an empty statement (e.g. a bare `;`).
+fn is_empty_expr(expr: &Expr) -> bool {
+   if let Expr::Verbatim(ts) = expr {
+        ts.is_empty()
+    } else {
+        false
+    }
+}
+
+/// Separates let statements from expressions in function body statements.
+/// Skips empty statements (bare `;`) which may be added by the cvlr_predicate! macro.
 fn separate_statements(stmts: &[Stmt]) -> syn::Result<(Vec<&Stmt>, Vec<Expr>)> {
     let mut let_statements = Vec::new();
     let mut expressions = Vec::new();
@@ -63,7 +73,11 @@ fn separate_statements(stmts: &[Stmt]) -> syn::Result<(Vec<&Stmt>, Vec<Expr>)> {
             // Stmt::Local represents let statements
             Stmt::Local(_) => let_statements.push(stmt),
             // Stmt::Expr covers both expressions with and without semicolons
-            Stmt::Expr(expr, _) => expressions.push(expr.clone()),
+            Stmt::Expr(expr, _) => {
+                if !is_empty_expr(expr) {
+                    expressions.push(expr.clone());
+                }
+            }
             _ => {
                 return Err(syn::Error::new(
                     Span::call_site(),

--- a/cvlr-macros/src/predicate.rs
+++ b/cvlr-macros/src/predicate.rs
@@ -55,7 +55,7 @@ fn extract_context_info(arg: &FnArg) -> syn::Result<(Type, syn::Ident)> {
 
 /// Returns true if the expression represents an empty statement (e.g. a bare `;`).
 fn is_empty_expr(expr: &Expr) -> bool {
-   if let Expr::Verbatim(ts) = expr {
+    if let Expr::Verbatim(ts) = expr {
         ts.is_empty()
     } else {
         false

--- a/cvlr-spec/Cargo.toml
+++ b/cvlr-spec/Cargo.toml
@@ -25,3 +25,4 @@ cvlr-macros = { workspace = true }
 
 [dev-dependencies]
 cvlr = { path = "../cvlr", features = ["rt", "no-loc"] }
+macrotest = { workspace = true }

--- a/cvlr-spec/src/macros.rs
+++ b/cvlr-spec/src/macros.rs
@@ -313,11 +313,11 @@ macro_rules! cvlr_def_states_predicates {
 /// and ensures predicates.
 #[macro_export]
 macro_rules! cvlr_predicate {
-    (| $c:ident : $ctx: ident | -> { $( $e: expr );* $(;)? } ) => {
+    (| $c:ident : $ctx: ident | -> { $( $s: stmt )+ } ) => {
         {
             #[$crate::__macro_support::cvlr_predicate]
             fn __anonymous_predicate($c: &$ctx) {
-                $( $e );* ;
+                $( $s )+ 
             }
             $crate::__macro_support::cvlr_pif!(__anonymous_predicate)
         }
@@ -487,16 +487,16 @@ macro_rules! cvlr_predicate {
 #[macro_export]
 macro_rules! cvlr_lemma {
     ($name: ident ( $c:ident : $ctx: ident ) {
-        requires -> { $( $requires: expr );* $(;)? }
-        ensures -> { $( $ensures: expr );* $(;)? } }) => {
+        requires -> { $( $requires: stmt )+ }
+        ensures -> { $( $ensures: stmt )+ } }) => {
             pub struct $name;
             impl $crate::spec::CvlrLemma for $name {
                 type Context = $ctx;
                 fn requires(&self) -> impl $crate::CvlrFormula<Context = Self::Context> {
-                    $crate::cvlr_predicate! { | $c : $ctx | -> { $( $requires );* } }
+                    $crate::cvlr_predicate! { | $c : $ctx | -> { $( $requires )+ } }
                 }
                 fn ensures(&self) -> impl $crate::CvlrFormula<Context = Self::Context> {
-                    $crate::cvlr_predicate! { | $c : $ctx | -> { $( $ensures );* } }
+                    $crate::cvlr_predicate! { | $c : $ctx | -> { $( $ensures )+ } }
                 }
             }
         };

--- a/cvlr-spec/src/macros.rs
+++ b/cvlr-spec/src/macros.rs
@@ -313,11 +313,11 @@ macro_rules! cvlr_def_states_predicates {
 /// and ensures predicates.
 #[macro_export]
 macro_rules! cvlr_predicate {
-    (| $c:ident : $ctx: ident | -> { $( $s: stmt )+ } ) => {
+    (| $c:ident : $ctx: ident | -> { $($body:tt)* } ) => {
         {
             #[$crate::__macro_support::cvlr_predicate]
             fn __anonymous_predicate($c: &$ctx) {
-                $( $s )+ 
+                $($body)*
             }
             $crate::__macro_support::cvlr_pif!(__anonymous_predicate)
         }
@@ -487,16 +487,16 @@ macro_rules! cvlr_predicate {
 #[macro_export]
 macro_rules! cvlr_lemma {
     ($name: ident ( $c:ident : $ctx: ident ) {
-        requires -> { $( $requires: stmt )+ }
-        ensures -> { $( $ensures: stmt )+ } }) => {
+        requires -> { $($requires:tt)* }
+        ensures -> { $($ensures:tt)* } }) => {
             pub struct $name;
             impl $crate::spec::CvlrLemma for $name {
                 type Context = $ctx;
                 fn requires(&self) -> impl $crate::CvlrFormula<Context = Self::Context> {
-                    $crate::cvlr_predicate! { | $c : $ctx | -> { $( $requires )+ } }
+                    $crate::cvlr_predicate! { | $c : $ctx | -> { $($requires)* } }
                 }
                 fn ensures(&self) -> impl $crate::CvlrFormula<Context = Self::Context> {
-                    $crate::cvlr_predicate! { | $c : $ctx | -> { $( $ensures )+ } }
+                    $crate::cvlr_predicate! { | $c : $ctx | -> { $($ensures)* } }
                 }
             }
         };

--- a/cvlr-spec/tests/expand/test_cvlr_predicate_multiple_stmts.expanded.rs
+++ b/cvlr-spec/tests/expand/test_cvlr_predicate_multiple_stmts.expanded.rs
@@ -1,0 +1,83 @@
+use cvlr_spec::cvlr_predicate;
+struct Ctx {
+    x: i32,
+    y: i32,
+}
+fn main() {
+    let _ = {
+        #[allow(unused_must_use, dead_code)]
+        fn __anonymous_predicate(c: &Ctx) {
+            c.x > 0;
+            c.y < 100;
+        }
+        struct AnonymousPredicate;
+        impl ::cvlr::spec::CvlrFormula for AnonymousPredicate {
+            type Context = Ctx;
+            fn eval(&self, ctx: &Self::Context) -> bool {
+                let c = ctx;
+                {
+                    let mut __cvlr_eval_res = true;
+                    __cvlr_eval_res = __cvlr_eval_res && { c.x > 0 };
+                    __cvlr_eval_res = __cvlr_eval_res && { c.y < 100 };
+                    __cvlr_eval_res
+                }
+            }
+            fn assert(&self, ctx: &Self::Context) {
+                let c = ctx;
+                {
+                    let __cvlr_lhs = c.x;
+                    let __cvlr_rhs = 0;
+                    cvlr::log::log_scope_start("assert");
+                    ::cvlr_log::cvlr_log("_", &("c.x > 0"));
+                    ::cvlr_log::cvlr_log("c.x", &(__cvlr_lhs));
+                    ::cvlr_log::cvlr_log("0", &(__cvlr_rhs));
+                    cvlr::log::log_scope_end("assert");
+                    {
+                        let c_ = __cvlr_lhs > __cvlr_rhs;
+                        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                        ::cvlr_asserts::cvlr_assert_checked(c_);
+                    };
+                };
+                {
+                    let __cvlr_lhs = c.y;
+                    let __cvlr_rhs = 100;
+                    cvlr::log::log_scope_start("assert");
+                    ::cvlr_log::cvlr_log("_", &("c.y < 100"));
+                    ::cvlr_log::cvlr_log("c.y", &(__cvlr_lhs));
+                    ::cvlr_log::cvlr_log("100", &(__cvlr_rhs));
+                    cvlr::log::log_scope_end("assert");
+                    {
+                        let c_ = __cvlr_lhs < __cvlr_rhs;
+                        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                        ::cvlr_asserts::cvlr_assert_checked(c_);
+                    };
+                };
+            }
+            fn assume(&self, ctx: &Self::Context) {
+                let c = ctx;
+                {
+                    let __cvlr_lhs = c.x;
+                    let __cvlr_rhs = 0;
+                    cvlr::log::log_scope_start("assume");
+                    ::cvlr_log::cvlr_log("_", &("c.x > 0"));
+                    ::cvlr_log::cvlr_log("c.x", &(__cvlr_lhs));
+                    ::cvlr_log::cvlr_log("0", &(__cvlr_rhs));
+                    cvlr::log::log_scope_end("assume");
+                    ::cvlr_asserts::cvlr_assume_checked(__cvlr_lhs > __cvlr_rhs);
+                };
+                {
+                    let __cvlr_lhs = c.y;
+                    let __cvlr_rhs = 100;
+                    cvlr::log::log_scope_start("assume");
+                    ::cvlr_log::cvlr_log("_", &("c.y < 100"));
+                    ::cvlr_log::cvlr_log("c.y", &(__cvlr_lhs));
+                    ::cvlr_log::cvlr_log("100", &(__cvlr_rhs));
+                    cvlr::log::log_scope_end("assume");
+                    ::cvlr_asserts::cvlr_assume_checked(__cvlr_lhs < __cvlr_rhs);
+                };
+            }
+        }
+        impl ::cvlr::spec::CvlrPredicate for AnonymousPredicate {}
+        AnonymousPredicate
+    };
+}

--- a/cvlr-spec/tests/expand/test_cvlr_predicate_multiple_stmts.rs
+++ b/cvlr-spec/tests/expand/test_cvlr_predicate_multiple_stmts.rs
@@ -1,0 +1,13 @@
+use cvlr_spec::cvlr_predicate;
+
+struct Ctx {
+    x: i32,
+    y: i32,
+}
+
+fn main() {
+    let _ = cvlr_predicate! { | c : Ctx | -> {
+        c.x > 0;
+        c.y < 100;
+    } };
+}

--- a/cvlr-spec/tests/expand/test_cvlr_predicate_simple.expanded.rs
+++ b/cvlr-spec/tests/expand/test_cvlr_predicate_simple.expanded.rs
@@ -1,0 +1,56 @@
+use cvlr_spec::cvlr_predicate;
+struct Ctx {
+    x: i32,
+}
+fn main() {
+    let _ = {
+        #[allow(unused_must_use, dead_code)]
+        fn __anonymous_predicate(c: &Ctx) {
+            c.x > 0;
+        }
+        struct AnonymousPredicate;
+        impl ::cvlr::spec::CvlrFormula for AnonymousPredicate {
+            type Context = Ctx;
+            fn eval(&self, ctx: &Self::Context) -> bool {
+                let c = ctx;
+                {
+                    let mut __cvlr_eval_res = true;
+                    __cvlr_eval_res = __cvlr_eval_res && { c.x > 0 };
+                    __cvlr_eval_res
+                }
+            }
+            fn assert(&self, ctx: &Self::Context) {
+                let c = ctx;
+                {
+                    let __cvlr_lhs = c.x;
+                    let __cvlr_rhs = 0;
+                    cvlr::log::log_scope_start("assert");
+                    ::cvlr_log::cvlr_log("_", &("c.x > 0"));
+                    ::cvlr_log::cvlr_log("c.x", &(__cvlr_lhs));
+                    ::cvlr_log::cvlr_log("0", &(__cvlr_rhs));
+                    cvlr::log::log_scope_end("assert");
+                    {
+                        let c_ = __cvlr_lhs > __cvlr_rhs;
+                        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                        ::cvlr_asserts::cvlr_assert_checked(c_);
+                    };
+                };
+            }
+            fn assume(&self, ctx: &Self::Context) {
+                let c = ctx;
+                {
+                    let __cvlr_lhs = c.x;
+                    let __cvlr_rhs = 0;
+                    cvlr::log::log_scope_start("assume");
+                    ::cvlr_log::cvlr_log("_", &("c.x > 0"));
+                    ::cvlr_log::cvlr_log("c.x", &(__cvlr_lhs));
+                    ::cvlr_log::cvlr_log("0", &(__cvlr_rhs));
+                    cvlr::log::log_scope_end("assume");
+                    ::cvlr_asserts::cvlr_assume_checked(__cvlr_lhs > __cvlr_rhs);
+                };
+            }
+        }
+        impl ::cvlr::spec::CvlrPredicate for AnonymousPredicate {}
+        AnonymousPredicate
+    };
+}

--- a/cvlr-spec/tests/expand/test_cvlr_predicate_simple.rs
+++ b/cvlr-spec/tests/expand/test_cvlr_predicate_simple.rs
@@ -1,0 +1,9 @@
+use cvlr_spec::cvlr_predicate;
+
+struct Ctx {
+    x: i32,
+}
+
+fn main() {
+    let _ = cvlr_predicate! { | c : Ctx | -> { c.x > 0; } };
+}

--- a/cvlr-spec/tests/expand/test_cvlr_predicate_with_let.expanded.rs
+++ b/cvlr-spec/tests/expand/test_cvlr_predicate_with_let.expanded.rs
@@ -1,0 +1,60 @@
+use cvlr_spec::cvlr_predicate;
+struct Ctx {
+    x: i32,
+}
+fn main() {
+    let _ = {
+        #[allow(unused_must_use, dead_code)]
+        fn __anonymous_predicate(c: &Ctx) {
+            let threshold = 0;
+            c.x > threshold;
+        }
+        struct AnonymousPredicate;
+        impl ::cvlr::spec::CvlrFormula for AnonymousPredicate {
+            type Context = Ctx;
+            fn eval(&self, ctx: &Self::Context) -> bool {
+                let c = ctx;
+                {
+                    let threshold = 0;
+                    let mut __cvlr_eval_res = true;
+                    __cvlr_eval_res = __cvlr_eval_res && { c.x > threshold };
+                    __cvlr_eval_res
+                }
+            }
+            fn assert(&self, ctx: &Self::Context) {
+                let c = ctx;
+                let threshold = 0;
+                {
+                    let __cvlr_lhs = c.x;
+                    let __cvlr_rhs = threshold;
+                    cvlr::log::log_scope_start("assert");
+                    ::cvlr_log::cvlr_log("_", &("c.x > threshold"));
+                    ::cvlr_log::cvlr_log("c.x", &(__cvlr_lhs));
+                    ::cvlr_log::cvlr_log("threshold", &(__cvlr_rhs));
+                    cvlr::log::log_scope_end("assert");
+                    {
+                        let c_ = __cvlr_lhs > __cvlr_rhs;
+                        ::cvlr_asserts::log::add_loc("<FILE>", 0u32);
+                        ::cvlr_asserts::cvlr_assert_checked(c_);
+                    };
+                };
+            }
+            fn assume(&self, ctx: &Self::Context) {
+                let c = ctx;
+                let threshold = 0;
+                {
+                    let __cvlr_lhs = c.x;
+                    let __cvlr_rhs = threshold;
+                    cvlr::log::log_scope_start("assume");
+                    ::cvlr_log::cvlr_log("_", &("c.x > threshold"));
+                    ::cvlr_log::cvlr_log("c.x", &(__cvlr_lhs));
+                    ::cvlr_log::cvlr_log("threshold", &(__cvlr_rhs));
+                    cvlr::log::log_scope_end("assume");
+                    ::cvlr_asserts::cvlr_assume_checked(__cvlr_lhs > __cvlr_rhs);
+                };
+            }
+        }
+        impl ::cvlr::spec::CvlrPredicate for AnonymousPredicate {}
+        AnonymousPredicate
+    };
+}

--- a/cvlr-spec/tests/expand/test_cvlr_predicate_with_let.rs
+++ b/cvlr-spec/tests/expand/test_cvlr_predicate_with_let.rs
@@ -1,0 +1,12 @@
+use cvlr_spec::cvlr_predicate;
+
+struct Ctx {
+    x: i32,
+}
+
+fn main() {
+    let _ = cvlr_predicate! { | c : Ctx | -> {
+        let threshold = 0;
+        c.x > threshold;
+    } };
+}

--- a/cvlr-spec/tests/test_doctest_examples.rs
+++ b/cvlr-spec/tests/test_doctest_examples.rs
@@ -19,7 +19,7 @@ fn test_cvlr_predicate_example() {
     // Create an anonymous predicate
     let pred = cvlr_predicate! { | c : Counter | -> {
         c.value > 0;
-        c.value < 100
+        c.value < 100;
     } };
 
     assert!(pred.eval(&ctx));
@@ -39,10 +39,10 @@ fn test_cvlr_lemma_example_syntax() {
     cvlr_lemma! {
         CounterPositiveLemma(c: Counter) {
             requires -> {
-                c.value > 0
+                c.value > 0;
             }
             ensures -> {
-                c.value > 0
+                c.value > 0;
             }
         }
     }
@@ -69,11 +69,11 @@ fn test_cvlr_lemma_complex_example() {
         CounterDoublesLemma(c: Counter) {
             requires -> {
                 c.value > 0;
-                c.value < 100
+                c.value < 100;
             }
             ensures -> {
                 c.value > 0;
-                c.value * 2 > c.value
+                c.value * 2 > c.value;
             }
         }
     }

--- a/cvlr-spec/tests/test_macro_expand.rs
+++ b/cvlr-spec/tests/test_macro_expand.rs
@@ -1,0 +1,6 @@
+//! Tests that validate macro expansion for cvlr-spec macros
+
+#[test]
+fn test_cvlr_predicate_macro_expansion() {
+    macrotest::expand("tests/expand/*.rs");
+}

--- a/cvlr-spec/tests/test_spec.rs
+++ b/cvlr-spec/tests/test_spec.rs
@@ -635,10 +635,10 @@ fn test_cvlr_predicate_with_let() {
     };
 
     let pred = cvlr_predicate! { | c : TestCtx | -> {
-        //let x = c.x;
-        // let y = c.y;
-        c.x > 0;
-        c.y > 0;
+        let x = c.x;
+        let y = c.y;
+        x > 0;
+        y > 0;
     } };
 
     assert!(pred.eval(&ctx));

--- a/cvlr-spec/tests/test_spec.rs
+++ b/cvlr-spec/tests/test_spec.rs
@@ -612,7 +612,7 @@ fn test_cvlr_predicate() {
 
     let pred = cvlr_predicate! { | c : TestCtx | -> {
         c.x > 0;
-        c.y > 0
+        c.y > 0;
     } };
 
     assert!(pred.eval(&ctx));
@@ -626,6 +626,34 @@ fn test_cvlr_predicate() {
 }
 
 #[test]
+fn test_cvlr_predicate_with_let() {
+    // Test cvlr_predicate! macro creates an anonymous predicate
+    let ctx = TestCtx {
+        x: 5,
+        y: 10,
+        flag: true,
+    };
+
+    let pred = cvlr_predicate! { | c : TestCtx | -> {
+        //let x = c.x;
+        // let y = c.y;
+        c.x > 0;
+        c.y > 0;
+    } };
+
+    assert!(pred.eval(&ctx));
+
+    let ctx2 = TestCtx {
+        x: -1,
+        y: 10,
+        flag: true,
+    };
+    assert!(!pred.eval(&ctx2));
+}
+
+
+
+#[test]
 fn test_cvlr_predicate_single_condition() {
     let ctx = TestCtx {
         x: 5,
@@ -634,7 +662,7 @@ fn test_cvlr_predicate_single_condition() {
     };
 
     let pred = cvlr_predicate! { | c : TestCtx | -> {
-        c.x > 0
+        c.x > 0;
     } };
 
     assert!(pred.eval(&ctx));
@@ -653,11 +681,11 @@ fn test_cvlr_lemma() {
     cvlr_lemma! {
         TestLemma(c: TestCtx) {
             requires -> {
-                c.x > 0
+                c.x > 0;
             }
             ensures -> {
                 c.x > 0;
-                c.y >= 0
+                c.y >= 0;
             }
         }
     }
@@ -695,10 +723,10 @@ fn test_cvlr_lemma_verify_with_context() {
     cvlr_lemma! {
         PositiveXLemma(c: TestCtx) {
             requires -> {
-                c.x > 0
+                c.x > 0;
             }
             ensures -> {
-                c.x > 0
+                c.x > 0;
             }
         }
     }
@@ -721,11 +749,11 @@ fn test_cvlr_lemma_apply() {
     cvlr_lemma! {
         XAndYPositiveLemma(c: TestCtx) {
             requires -> {
-                c.x > 0
+                c.x > 0;
             }
             ensures -> {
                 c.x > 0;
-                c.y > 0
+                c.y > 0;
             }
         }
     }
@@ -750,12 +778,12 @@ fn test_cvlr_lemma_multiple_conditions() {
             requires -> {
                 c.x > 0;
                 c.y > 0;
-                c.flag
+                c.flag;
             }
             ensures -> {
                 c.x > 0;
                 c.y > 0;
-                c.x + c.y > 10
+                c.x + c.y > 10;
             }
         }
     }
@@ -796,14 +824,14 @@ impl cvlr_spec::spec::CvlrLemma for ManualLemma {
     type Context = TestCtx;
     fn requires(&self) -> impl CvlrFormula<Context = Self::Context> {
         cvlr_predicate! { | c : TestCtx | -> {
-            c.x > 0
+            c.x > 0;
         } }
     }
 
     fn ensures(&self) -> impl CvlrFormula<Context = Self::Context> {
         cvlr_predicate! { | c : TestCtx | -> {
             c.x > 0;
-            c.y > 0
+            c.y > 0;
         } }
     }
 }
@@ -836,11 +864,11 @@ fn test_cvlr_lemma_requires_ensures_interaction() {
     cvlr_lemma! {
         ImplicationLemma(c: TestCtx) {
             requires -> {
-                c.x > 0
+                c.x > 0;
             }
             ensures -> {
                 c.x > 0;
-                c.y == c.x * 2
+                c.y == c.x * 2;
             }
         }
     }
@@ -1005,8 +1033,8 @@ fn test_cvlr_spec_macro() {
 fn test_cvlr_spec_macro_with_predicates() {
     // Test cvlr_spec! macro with cvlr_predicate!
     let spec = cvlr_spec! {
-        requires: cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
-        ensures: cvlr_predicate! { | c : TestCtx | -> { c.y > 0 } }
+        requires: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
+        ensures: cvlr_predicate! { | c : TestCtx | -> { c.y > 0; } }
     };
 
     let pre = TestCtx {
@@ -1049,8 +1077,8 @@ fn test_cvlr_invar_spec_macro() {
 fn test_cvlr_invar_spec_macro_with_predicates() {
     // Test cvlr_invar_spec! macro with cvlr_predicate!
     let spec = cvlr_invar_spec! {
-        assumption: cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
-        invariant: cvlr_predicate! { | c : TestCtx | -> { c.y > 0 } }
+        assumption: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
+        invariant: cvlr_predicate! { | c : TestCtx | -> { c.y > 0; } }
     };
 
     let ctx = TestCtx {
@@ -1134,8 +1162,8 @@ fn test_cvlr_invariant_rules_macro() {
     // Define invariant rules for multiple functions
     cvlr_invariant_rules! {
         name: "non_negative",
-        assumption: cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
-        invariant: cvlr_predicate! { | c : TestCtx | -> { c.y >= 0 } },
+        assumption: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
+        invariant: cvlr_predicate! { | c : TestCtx | -> { c.y >= 0; } },
         bases: [
             base_update_counter,
             base_reset_counter,
@@ -1203,8 +1231,8 @@ fn test_cvlr_and_macro_with_expressions() {
         flag: true,
     };
     let expr = cvlr_and!(
-        cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
-        cvlr_predicate! { | c : TestCtx | -> { c.y > 0 } }
+        cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
+        cvlr_predicate! { | c : TestCtx | -> { c.y > 0; } }
     );
     assert!(expr.eval(&ctx));
 
@@ -1226,12 +1254,12 @@ fn test_cvlr_and_macro_mixed_ident_expr() {
     };
     let expr1 = cvlr_and!(
         XPositive,
-        cvlr_predicate! { | c : TestCtx | -> { c.y > 0 } }
+        cvlr_predicate! { | c : TestCtx | -> { c.y > 0; } }
     );
     assert!(expr1.eval(&ctx));
 
     let expr2 = cvlr_and!(
-        cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
+        cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
         YPositive
     );
     assert!(expr2.eval(&ctx));
@@ -1270,7 +1298,7 @@ fn test_cvlr_and_macro_four_args() {
         XPositive,
         YPositive,
         true_expr,
-        cvlr_predicate! { | c : TestCtx | -> { c.flag } }
+        cvlr_predicate! { | c : TestCtx | -> { c.flag; } }
     );
     assert!(expr.eval(&ctx));
 
@@ -1295,8 +1323,8 @@ fn test_cvlr_and_macro_five_args() {
         XPositive,
         YPositive,
         true_expr,
-        cvlr_predicate! { | c : TestCtx | -> { c.flag } },
-        cvlr_predicate! { | c : TestCtx | -> { c.x + c.y > 0 } }
+        cvlr_predicate! { | c : TestCtx | -> { c.flag; } },
+        cvlr_predicate! { | c : TestCtx | -> { c.x + c.y > 0; } }
     );
     assert!(expr.eval(&ctx));
 
@@ -1321,9 +1349,9 @@ fn test_cvlr_and_macro_six_args() {
         XPositive,
         YPositive,
         true_expr,
-        cvlr_predicate! { | c : TestCtx | -> { c.flag } },
-        cvlr_predicate! { | c : TestCtx | -> { c.x + c.y > 0 } },
-        cvlr_predicate! { | c : TestCtx | -> { c.x * c.y > 0 } }
+        cvlr_predicate! { | c : TestCtx | -> { c.flag; } },
+        cvlr_predicate! { | c : TestCtx | -> { c.x + c.y > 0; } },
+        cvlr_predicate! { | c : TestCtx | -> { c.x * c.y > 0; } }
     );
     assert!(expr.eval(&ctx));
 
@@ -1430,8 +1458,8 @@ fn test_cvlr_implies_macro_with_expressions() {
         flag: true,
     };
     let expr = cvlr_implies!(
-        cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
-        cvlr_predicate! { | c : TestCtx | -> { c.y > 0 } }
+        cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
+        cvlr_predicate! { | c : TestCtx | -> { c.y > 0; } }
     );
     assert!(expr.eval(&ctx));
 
@@ -1454,13 +1482,13 @@ fn test_cvlr_implies_macro_mixed_ident_expr() {
     // Identifier as antecedent, expression as consequent
     let expr1 = cvlr_implies!(
         XPositive,
-        cvlr_predicate! { | c : TestCtx | -> { c.y > 0 } }
+        cvlr_predicate! { | c : TestCtx | -> { c.y > 0; } }
     );
     assert!(expr1.eval(&ctx));
 
     // Expression as antecedent, identifier as consequent
     let expr2 = cvlr_implies!(
-        cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
+        cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
         YPositive
     );
     assert!(expr2.eval(&ctx));
@@ -1579,7 +1607,7 @@ fn test_cvlr_and_macro_nested() {
         flag: true,
     };
     let inner = cvlr_and!(XPositive, YPositive);
-    let outer = cvlr_and!(inner, cvlr_predicate! { | c : TestCtx | -> { c.flag } });
+    let outer = cvlr_and!(inner, cvlr_predicate! { | c : TestCtx | -> { c.flag; } });
     assert!(outer.eval(&ctx));
 
     let ctx2 = TestCtx {
@@ -1596,8 +1624,8 @@ fn test_cvlr_lemma_new_branch_basic() {
     // Test the new branch syntax: StructName for Context { requires: expr, ensures: expr }
     cvlr_lemma! {
         BasicLemmaNew for TestCtx {
-            requires: cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
-            ensures: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; c.y >= 0 } },
+            requires: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
+            ensures: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; c.y >= 0; } },
         }
     }
 
@@ -1705,8 +1733,8 @@ fn test_cvlr_lemma_new_branch_verify_with_context() {
     // Test verify_with_context with the new branch
     cvlr_lemma! {
         VerifyLemmaNew for TestCtx {
-            requires: cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
-            ensures: cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
+            requires: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
+            ensures: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
         }
     }
 
@@ -1752,12 +1780,12 @@ fn test_cvlr_lemma_new_branch_multiple_conditions() {
             requires: cvlr_and!(
                 XPositive,
                 YPositive,
-                cvlr_predicate! { | c : TestCtx | -> { c.flag } }
+                cvlr_predicate! { | c : TestCtx | -> { c.flag; } }
             ),
             ensures: cvlr_and!(
                 XPositive,
                 YPositive,
-                cvlr_predicate! { | c : TestCtx | -> { c.x + c.y > 10 } }
+                cvlr_predicate! { | c : TestCtx | -> { c.x + c.y > 10; } }
             ),
         }
     }
@@ -1796,11 +1824,11 @@ fn test_cvlr_lemma_new_branch_mixed_expressions() {
         MixedExpressionsLemmaNew for TestCtx {
             requires: cvlr_and!(
                 XPositive,
-                cvlr_predicate! { | c : TestCtx | -> { c.y > 0 } }
+                cvlr_predicate! { | c : TestCtx | -> { c.y > 0; } }
             ),
             ensures: cvlr_implies!(
                 YPositive,
-                cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } }
+                cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } }
             ),
         }
     }
@@ -1851,8 +1879,8 @@ fn test_cvlr_lemma_new_branch_requires_ensures_interaction() {
     // Test that requires and ensures can be independent in the new branch
     cvlr_lemma! {
         InteractionLemmaNew for TestCtx {
-            requires: cvlr_predicate! { | c : TestCtx | -> { c.x > 0 } },
-            ensures: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; c.y == c.x * 2 } },
+            requires: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; } },
+            ensures: cvlr_predicate! { | c : TestCtx | -> { c.x > 0; c.y == c.x * 2; } },
         }
     }
 

--- a/cvlr-spec/tests/test_spec.rs
+++ b/cvlr-spec/tests/test_spec.rs
@@ -651,8 +651,6 @@ fn test_cvlr_predicate_with_let() {
     assert!(!pred.eval(&ctx2));
 }
 
-
-
 #[test]
 fn test_cvlr_predicate_single_condition() {
     let ctx = TestCtx {


### PR DESCRIPTION
Change `cvlr_predicate!` and `cvlr_lemma!` macros to accept arbitrary tokens in predicate bodies. The decision on what is legal syntax is forwarded to `cvlr_predicate` attribute. This ensures that single syntax is preserved across all different uses.