### PR TITLE
Allow empty input for `cvlr_assert_all` macros

### DIFF
--- a/cvlr-macros/src/assert_that.rs
+++ b/cvlr-macros/src/assert_that.rs
@@ -184,6 +184,11 @@ impl Parse for AssertAllInput {
         let mut expressions = Vec::new();
 
         loop {
+            // Allow empty input (no-op)
+            if input.is_empty() {
+                break;
+            }
+
             // Parse one expression
             let expr: AssertThatInput = input.parse()?;
             expressions.push(expr);
@@ -195,11 +200,6 @@ impl Parse for AssertAllInput {
                 let _: Token![;] = input.parse()?;
             } else {
                 // No more separators, we're done
-                break;
-            }
-
-            // Check if we're at the end
-            if input.is_empty() {
                 break;
             }
         }

--- a/cvlr-macros/tests/expand/test_cvlr_assert_all.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_all.expanded.rs
@@ -487,4 +487,7 @@ pub fn test_assert_all_boolean_expressions() {
         ::cvlr_asserts::cvlr_assert_checked(c_);
     };
 }
-pub fn main() {}
+pub fn test_assert_all_empty() {}
+pub fn main() {
+    test_assert_all_empty();
+}

--- a/cvlr-macros/tests/expand/test_cvlr_assert_all.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assert_all.rs
@@ -75,4 +75,10 @@ pub fn test_assert_all_boolean_expressions() {
     cvlr_assert_all!((((flag))), ((x > 0 && y < 10)));
 }
 
-pub fn main() {}
+pub fn test_assert_all_empty() {
+    cvlr_assert_all!();
+}
+
+pub fn main() {
+    test_assert_all_empty();
+}

--- a/cvlr-macros/tests/expand/test_cvlr_assume_all.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assume_all.expanded.rs
@@ -359,4 +359,7 @@ pub fn test_assume_all_mixed_guarded_unguarded() {
         ::cvlr_asserts::cvlr_assume_checked(__cvlr_lhs < __cvlr_rhs);
     };
 }
-pub fn main() {}
+pub fn test_assume_all_empty() {}
+pub fn main() {
+    test_assume_all_empty();
+}

--- a/cvlr-macros/tests/expand/test_cvlr_assume_all.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_assume_all.rs
@@ -64,4 +64,13 @@ pub fn test_assume_all_mixed_guarded_unguarded() {
     cvlr_assume_all!((x > 0), if flag { a < b } else { true }, (y < 20));
 }
 
-pub fn main() {}
+pub fn test_assume_all_empty() { 
+    cvlr_assume_all!{
+        // x > 0;
+        // y < x;
+    };
+}
+
+pub fn main() {
+    test_assume_all_empty();
+}

--- a/cvlr-macros/tests/expand/test_cvlr_eval_all.expanded.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_eval_all.expanded.rs
@@ -59,6 +59,13 @@ pub fn test_eval_all() {
         __cvlr_eval_all_res
     };
 }
+pub fn test_eval_all_empty() {
+    let _ = {
+        let __cvlr_eval_all_res = true;
+        __cvlr_eval_all_res
+    };
+}
 pub fn main() {
     test_eval_all();
+    test_eval_all_empty();
 }

--- a/cvlr-macros/tests/expand/test_cvlr_eval_all.rs
+++ b/cvlr-macros/tests/expand/test_cvlr_eval_all.rs
@@ -30,7 +30,12 @@ pub fn test_eval_all() {
     let _result7 = cvlr_eval_all!(x + 1 > 0, y * 2 < 30, if a > 0 { b < 10 } else { true });
 }
 
+pub fn test_eval_all_empty() {
+    let _ = cvlr_eval_all!();
+}
+
 pub fn main() {
     test_eval_all();
+    test_eval_all_empty();
 }
 


### PR DESCRIPTION
This fixes the issue where empty input was not allowed for `cvlr_assert_all` macros. 
This is especially helpful for debugging when disabling some assumes/asserts. 

For example, this now works as expected
```
  cvlr_assume_all!{
    // x > 0;
    // y < x;
  };
```