### PR TITLE
fix runtime error due to missing impl of `CVT_calltrace_attach_location` in `rt`

### DIFF
--- a/cvlr-asserts/src/log.rs
+++ b/cvlr-asserts/src/log.rs
@@ -6,6 +6,12 @@ mod rt_decls {
     }
 }
 
+#[cfg(feature = "rt")]
+mod rt_impls {
+    #[no_mangle]
+    pub extern "C" fn CVT_calltrace_attach_location(_: &str, _: u64) {}
+}
+
 #[inline(always)]
 pub fn add_loc(file: &str, line: u32) {
     unsafe {

--- a/cvlr-nondet/src/lib.rs
+++ b/cvlr-nondet/src/lib.rs
@@ -3,9 +3,9 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-mod core;
-mod option;
-mod scalars;
+pub mod core;
+pub mod option;
+pub mod scalars;
 
 #[cfg(feature = "std")]
 pub mod havoc;

--- a/cvlr-nondet/src/lib.rs
+++ b/cvlr-nondet/src/lib.rs
@@ -3,9 +3,9 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-pub mod core;
-pub mod option;
-pub mod scalars;
+mod core;
+mod option;
+mod scalars;
 
 #[cfg(feature = "std")]
 pub mod havoc;


### PR DESCRIPTION
this PR fixes 2 issues (that exist in current `main`) in feature `rt`
1. ~~compilation of `cvlr-solana` with fails due to things being non-pub~~ (edit: no, and this is reverted)
2. the non-existing impl of `CVT_calltrace_attach_location` causes missing symbol error (when the expected behavior is to do nothing)